### PR TITLE
Display and Update Intervention Activities and Events

### DIFF
--- a/BackPortal.xcodeproj/project.pbxproj
+++ b/BackPortal.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		B45316551EF847EB004A8FD9 /* NoSelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45316541EF847EB004A8FD9 /* NoSelectionViewController.swift */; };
 		B45316571EF84D46004A8FD9 /* UIViewController+Portal.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45316561EF84D46004A8FD9 /* UIViewController+Portal.swift */; };
 		B45316591EF84F87004A8FD9 /* PatientMasterNavController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45316581EF84F87004A8FD9 /* PatientMasterNavController.swift */; };
+		B453165B1EF97A7D004A8FD9 /* InterventionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B453165A1EF97A7D004A8FD9 /* InterventionCell.swift */; };
 		B4C2BE1C1EF823D200E70A31 /* ActiviesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C2BE1B1EF823D200E70A31 /* ActiviesViewController.swift */; };
 		B4C2BE1E1EF8328100E70A31 /* PatientDetailNavController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C2BE1D1EF8328100E70A31 /* PatientDetailNavController.swift */; };
 		E3E647F8FB412EE4983BFCCF /* Pods_BackPortalUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B9CB4F026613D1FC355F9B5 /* Pods_BackPortalUITests.framework */; };
@@ -90,6 +91,7 @@
 		B45316541EF847EB004A8FD9 /* NoSelectionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoSelectionViewController.swift; sourceTree = "<group>"; };
 		B45316561EF84D46004A8FD9 /* UIViewController+Portal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+Portal.swift"; sourceTree = "<group>"; };
 		B45316581EF84F87004A8FD9 /* PatientMasterNavController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatientMasterNavController.swift; sourceTree = "<group>"; };
+		B453165A1EF97A7D004A8FD9 /* InterventionCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterventionCell.swift; sourceTree = "<group>"; };
 		B4C2BE1B1EF823D200E70A31 /* ActiviesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActiviesViewController.swift; sourceTree = "<group>"; };
 		B4C2BE1D1EF8328100E70A31 /* PatientDetailNavController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatientDetailNavController.swift; sourceTree = "<group>"; };
 		B7D0E29578B809FC4C0276D6 /* Pods-BackPortalTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BackPortalTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-BackPortalTests/Pods-BackPortalTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -231,6 +233,7 @@
 				B41DC0261EF2FD9100B7DAE9 /* Account.storyboard */,
 				B41DC02D1EF324E500B7DAE9 /* Patients.storyboard */,
 				B41DC0321EF3306900B7DAE9 /* PatientCell.swift */,
+				B453165A1EF97A7D004A8FD9 /* InterventionCell.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -548,6 +551,7 @@
 				B4C2BE1C1EF823D200E70A31 /* ActiviesViewController.swift in Sources */,
 				B41DC0311EF32A8B00B7DAE9 /* PatientListViewController.swift in Sources */,
 				B41DC0281EF2FE0600B7DAE9 /* AccountViewController.swift in Sources */,
+				B453165B1EF97A7D004A8FD9 /* InterventionCell.swift in Sources */,
 				B41DC01A1EF2E3F200B7DAE9 /* AlertUtils.swift in Sources */,
 				B41DC0211EF2FB6500B7DAE9 /* MainPanelViewController.swift in Sources */,
 				B4C2BE1E1EF8328100E70A31 /* PatientDetailNavController.swift in Sources */,

--- a/BackPortal.xcodeproj/project.pbxproj
+++ b/BackPortal.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		B4297F181EF2D5FF00A0DE1F /* Application.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B4297F1A1EF2D5FF00A0DE1F /* Application.storyboard */; };
 		B4297F1D1EF2D63C00A0DE1F /* ApplicationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4297F1C1EF2D63C00A0DE1F /* ApplicationViewController.swift */; };
 		B45316531EF83E0A004A8FD9 /* PatientDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45316521EF83E0A004A8FD9 /* PatientDetailViewController.swift */; };
+		B45316551EF847EB004A8FD9 /* NoSelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45316541EF847EB004A8FD9 /* NoSelectionViewController.swift */; };
 		B4C2BE1C1EF823D200E70A31 /* ActiviesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C2BE1B1EF823D200E70A31 /* ActiviesViewController.swift */; };
 		B4C2BE1E1EF8328100E70A31 /* PatientDetailNavController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C2BE1D1EF8328100E70A31 /* PatientDetailNavController.swift */; };
 		E3E647F8FB412EE4983BFCCF /* Pods_BackPortalUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B9CB4F026613D1FC355F9B5 /* Pods_BackPortalUITests.framework */; };
@@ -84,6 +85,7 @@
 		B4297F191EF2D5FF00A0DE1F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Application.storyboard; sourceTree = "<group>"; };
 		B4297F1C1EF2D63C00A0DE1F /* ApplicationViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApplicationViewController.swift; sourceTree = "<group>"; };
 		B45316521EF83E0A004A8FD9 /* PatientDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatientDetailViewController.swift; sourceTree = "<group>"; };
+		B45316541EF847EB004A8FD9 /* NoSelectionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoSelectionViewController.swift; sourceTree = "<group>"; };
 		B4C2BE1B1EF823D200E70A31 /* ActiviesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActiviesViewController.swift; sourceTree = "<group>"; };
 		B4C2BE1D1EF8328100E70A31 /* PatientDetailNavController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatientDetailNavController.swift; sourceTree = "<group>"; };
 		B7D0E29578B809FC4C0276D6 /* Pods-BackPortalTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BackPortalTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-BackPortalTests/Pods-BackPortalTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -238,6 +240,7 @@
 				B41DC0271EF2FE0600B7DAE9 /* AccountViewController.swift */,
 				B41DC02E1EF325E600B7DAE9 /* PatientSplitViewController.swift */,
 				B41DC0301EF32A8B00B7DAE9 /* PatientListViewController.swift */,
+				B45316541EF847EB004A8FD9 /* NoSelectionViewController.swift */,
 				B4C2BE1D1EF8328100E70A31 /* PatientDetailNavController.swift */,
 				B45316521EF83E0A004A8FD9 /* PatientDetailViewController.swift */,
 				B4C2BE1B1EF823D200E70A31 /* ActiviesViewController.swift */,
@@ -531,6 +534,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B45316551EF847EB004A8FD9 /* NoSelectionViewController.swift in Sources */,
 				B4297EDD1EF2D1D300A0DE1F /* PortalAppDelegate.swift in Sources */,
 				B45316531EF83E0A004A8FD9 /* PatientDetailViewController.swift in Sources */,
 				B4297F1D1EF2D63C00A0DE1F /* ApplicationViewController.swift in Sources */,

--- a/BackPortal.xcodeproj/project.pbxproj
+++ b/BackPortal.xcodeproj/project.pbxproj
@@ -29,7 +29,9 @@
 		B4297F131EF2D4D500A0DE1F /* Launch.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B4297F151EF2D4D500A0DE1F /* Launch.storyboard */; };
 		B4297F181EF2D5FF00A0DE1F /* Application.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B4297F1A1EF2D5FF00A0DE1F /* Application.storyboard */; };
 		B4297F1D1EF2D63C00A0DE1F /* ApplicationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4297F1C1EF2D63C00A0DE1F /* ApplicationViewController.swift */; };
+		B45316531EF83E0A004A8FD9 /* PatientDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45316521EF83E0A004A8FD9 /* PatientDetailViewController.swift */; };
 		B4C2BE1C1EF823D200E70A31 /* ActiviesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C2BE1B1EF823D200E70A31 /* ActiviesViewController.swift */; };
+		B4C2BE1E1EF8328100E70A31 /* PatientDetailNavController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C2BE1D1EF8328100E70A31 /* PatientDetailNavController.swift */; };
 		E3E647F8FB412EE4983BFCCF /* Pods_BackPortalUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B9CB4F026613D1FC355F9B5 /* Pods_BackPortalUITests.framework */; };
 /* End PBXBuildFile section */
 
@@ -81,7 +83,9 @@
 		B4297F141EF2D4D500A0DE1F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Launch.storyboard; sourceTree = "<group>"; };
 		B4297F191EF2D5FF00A0DE1F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Application.storyboard; sourceTree = "<group>"; };
 		B4297F1C1EF2D63C00A0DE1F /* ApplicationViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApplicationViewController.swift; sourceTree = "<group>"; };
+		B45316521EF83E0A004A8FD9 /* PatientDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatientDetailViewController.swift; sourceTree = "<group>"; };
 		B4C2BE1B1EF823D200E70A31 /* ActiviesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActiviesViewController.swift; sourceTree = "<group>"; };
+		B4C2BE1D1EF8328100E70A31 /* PatientDetailNavController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatientDetailNavController.swift; sourceTree = "<group>"; };
 		B7D0E29578B809FC4C0276D6 /* Pods-BackPortalTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BackPortalTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-BackPortalTests/Pods-BackPortalTests.release.xcconfig"; sourceTree = "<group>"; };
 		BBB4850FC2AFCB732D18AAF8 /* Pods_BackPortalTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BackPortalTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E25F22207946ED8182DCFB92 /* Pods-BackPortal.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BackPortal.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BackPortal/Pods-BackPortal.debug.xcconfig"; sourceTree = "<group>"; };
@@ -234,6 +238,8 @@
 				B41DC0271EF2FE0600B7DAE9 /* AccountViewController.swift */,
 				B41DC02E1EF325E600B7DAE9 /* PatientSplitViewController.swift */,
 				B41DC0301EF32A8B00B7DAE9 /* PatientListViewController.swift */,
+				B4C2BE1D1EF8328100E70A31 /* PatientDetailNavController.swift */,
+				B45316521EF83E0A004A8FD9 /* PatientDetailViewController.swift */,
 				B4C2BE1B1EF823D200E70A31 /* ActiviesViewController.swift */,
 			);
 			path = ViewControllers;
@@ -526,12 +532,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				B4297EDD1EF2D1D300A0DE1F /* PortalAppDelegate.swift in Sources */,
+				B45316531EF83E0A004A8FD9 /* PatientDetailViewController.swift in Sources */,
 				B4297F1D1EF2D63C00A0DE1F /* ApplicationViewController.swift in Sources */,
 				B4C2BE1C1EF823D200E70A31 /* ActiviesViewController.swift in Sources */,
 				B41DC0311EF32A8B00B7DAE9 /* PatientListViewController.swift in Sources */,
 				B41DC0281EF2FE0600B7DAE9 /* AccountViewController.swift in Sources */,
 				B41DC01A1EF2E3F200B7DAE9 /* AlertUtils.swift in Sources */,
 				B41DC0211EF2FB6500B7DAE9 /* MainPanelViewController.swift in Sources */,
+				B4C2BE1E1EF8328100E70A31 /* PatientDetailNavController.swift in Sources */,
 				B41DC0181EF2DF5900B7DAE9 /* AuthViewController.swift in Sources */,
 				B41DC00F1EF2D9CC00B7DAE9 /* PortalSecrets.swift in Sources */,
 				B41DC0331EF3306900B7DAE9 /* PatientCell.swift in Sources */,

--- a/BackPortal.xcodeproj/project.pbxproj
+++ b/BackPortal.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		B4297F1D1EF2D63C00A0DE1F /* ApplicationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4297F1C1EF2D63C00A0DE1F /* ApplicationViewController.swift */; };
 		B45316531EF83E0A004A8FD9 /* PatientDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45316521EF83E0A004A8FD9 /* PatientDetailViewController.swift */; };
 		B45316551EF847EB004A8FD9 /* NoSelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45316541EF847EB004A8FD9 /* NoSelectionViewController.swift */; };
+		B45316571EF84D46004A8FD9 /* UIViewController+Portal.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45316561EF84D46004A8FD9 /* UIViewController+Portal.swift */; };
+		B45316591EF84F87004A8FD9 /* PatientMasterNavController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45316581EF84F87004A8FD9 /* PatientMasterNavController.swift */; };
 		B4C2BE1C1EF823D200E70A31 /* ActiviesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C2BE1B1EF823D200E70A31 /* ActiviesViewController.swift */; };
 		B4C2BE1E1EF8328100E70A31 /* PatientDetailNavController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C2BE1D1EF8328100E70A31 /* PatientDetailNavController.swift */; };
 		E3E647F8FB412EE4983BFCCF /* Pods_BackPortalUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B9CB4F026613D1FC355F9B5 /* Pods_BackPortalUITests.framework */; };
@@ -86,6 +88,8 @@
 		B4297F1C1EF2D63C00A0DE1F /* ApplicationViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApplicationViewController.swift; sourceTree = "<group>"; };
 		B45316521EF83E0A004A8FD9 /* PatientDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatientDetailViewController.swift; sourceTree = "<group>"; };
 		B45316541EF847EB004A8FD9 /* NoSelectionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoSelectionViewController.swift; sourceTree = "<group>"; };
+		B45316561EF84D46004A8FD9 /* UIViewController+Portal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+Portal.swift"; sourceTree = "<group>"; };
+		B45316581EF84F87004A8FD9 /* PatientMasterNavController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatientMasterNavController.swift; sourceTree = "<group>"; };
 		B4C2BE1B1EF823D200E70A31 /* ActiviesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActiviesViewController.swift; sourceTree = "<group>"; };
 		B4C2BE1D1EF8328100E70A31 /* PatientDetailNavController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatientDetailNavController.swift; sourceTree = "<group>"; };
 		B7D0E29578B809FC4C0276D6 /* Pods-BackPortalTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BackPortalTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-BackPortalTests/Pods-BackPortalTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -234,11 +238,13 @@
 		B4297F1B1EF2D61D00A0DE1F /* ViewControllers */ = {
 			isa = PBXGroup;
 			children = (
+				B45316561EF84D46004A8FD9 /* UIViewController+Portal.swift */,
 				B4297F1C1EF2D63C00A0DE1F /* ApplicationViewController.swift */,
 				B41DC0171EF2DF5900B7DAE9 /* AuthViewController.swift */,
 				B41DC0201EF2FB6500B7DAE9 /* MainPanelViewController.swift */,
 				B41DC0271EF2FE0600B7DAE9 /* AccountViewController.swift */,
 				B41DC02E1EF325E600B7DAE9 /* PatientSplitViewController.swift */,
+				B45316581EF84F87004A8FD9 /* PatientMasterNavController.swift */,
 				B41DC0301EF32A8B00B7DAE9 /* PatientListViewController.swift */,
 				B45316541EF847EB004A8FD9 /* NoSelectionViewController.swift */,
 				B4C2BE1D1EF8328100E70A31 /* PatientDetailNavController.swift */,
@@ -536,6 +542,7 @@
 			files = (
 				B45316551EF847EB004A8FD9 /* NoSelectionViewController.swift in Sources */,
 				B4297EDD1EF2D1D300A0DE1F /* PortalAppDelegate.swift in Sources */,
+				B45316571EF84D46004A8FD9 /* UIViewController+Portal.swift in Sources */,
 				B45316531EF83E0A004A8FD9 /* PatientDetailViewController.swift in Sources */,
 				B4297F1D1EF2D63C00A0DE1F /* ApplicationViewController.swift in Sources */,
 				B4C2BE1C1EF823D200E70A31 /* ActiviesViewController.swift in Sources */,
@@ -546,6 +553,7 @@
 				B4C2BE1E1EF8328100E70A31 /* PatientDetailNavController.swift in Sources */,
 				B41DC0181EF2DF5900B7DAE9 /* AuthViewController.swift in Sources */,
 				B41DC00F1EF2D9CC00B7DAE9 /* PortalSecrets.swift in Sources */,
+				B45316591EF84F87004A8FD9 /* PatientMasterNavController.swift in Sources */,
 				B41DC0331EF3306900B7DAE9 /* PatientCell.swift in Sources */,
 				B41DC0161EF2DE3D00B7DAE9 /* DispatchUtils.swift in Sources */,
 				B41DC02F1EF325E600B7DAE9 /* PatientSplitViewController.swift in Sources */,

--- a/BackPortal.xcodeproj/project.pbxproj
+++ b/BackPortal.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		B4297F131EF2D4D500A0DE1F /* Launch.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B4297F151EF2D4D500A0DE1F /* Launch.storyboard */; };
 		B4297F181EF2D5FF00A0DE1F /* Application.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B4297F1A1EF2D5FF00A0DE1F /* Application.storyboard */; };
 		B4297F1D1EF2D63C00A0DE1F /* ApplicationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4297F1C1EF2D63C00A0DE1F /* ApplicationViewController.swift */; };
+		B4C2BE1C1EF823D200E70A31 /* ActiviesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C2BE1B1EF823D200E70A31 /* ActiviesViewController.swift */; };
 		E3E647F8FB412EE4983BFCCF /* Pods_BackPortalUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B9CB4F026613D1FC355F9B5 /* Pods_BackPortalUITests.framework */; };
 /* End PBXBuildFile section */
 
@@ -80,6 +81,7 @@
 		B4297F141EF2D4D500A0DE1F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Launch.storyboard; sourceTree = "<group>"; };
 		B4297F191EF2D5FF00A0DE1F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Application.storyboard; sourceTree = "<group>"; };
 		B4297F1C1EF2D63C00A0DE1F /* ApplicationViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApplicationViewController.swift; sourceTree = "<group>"; };
+		B4C2BE1B1EF823D200E70A31 /* ActiviesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActiviesViewController.swift; sourceTree = "<group>"; };
 		B7D0E29578B809FC4C0276D6 /* Pods-BackPortalTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BackPortalTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-BackPortalTests/Pods-BackPortalTests.release.xcconfig"; sourceTree = "<group>"; };
 		BBB4850FC2AFCB732D18AAF8 /* Pods_BackPortalTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BackPortalTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E25F22207946ED8182DCFB92 /* Pods-BackPortal.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BackPortal.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BackPortal/Pods-BackPortal.debug.xcconfig"; sourceTree = "<group>"; };
@@ -232,6 +234,7 @@
 				B41DC0271EF2FE0600B7DAE9 /* AccountViewController.swift */,
 				B41DC02E1EF325E600B7DAE9 /* PatientSplitViewController.swift */,
 				B41DC0301EF32A8B00B7DAE9 /* PatientListViewController.swift */,
+				B4C2BE1B1EF823D200E70A31 /* ActiviesViewController.swift */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -524,6 +527,7 @@
 			files = (
 				B4297EDD1EF2D1D300A0DE1F /* PortalAppDelegate.swift in Sources */,
 				B4297F1D1EF2D63C00A0DE1F /* ApplicationViewController.swift in Sources */,
+				B4C2BE1C1EF823D200E70A31 /* ActiviesViewController.swift in Sources */,
 				B41DC0311EF32A8B00B7DAE9 /* PatientListViewController.swift in Sources */,
 				B41DC0281EF2FE0600B7DAE9 /* AccountViewController.swift in Sources */,
 				B41DC01A1EF2E3F200B7DAE9 /* AlertUtils.swift in Sources */,

--- a/BackPortal/ViewControllers/ActiviesViewController.swift
+++ b/BackPortal/ViewControllers/ActiviesViewController.swift
@@ -31,10 +31,28 @@ class ActiviesViewController: UICollectionViewController {
 
 // MARK: UICollectionViewDelegateFlowLayout
 
+fileprivate let PortalCellCellInternalSpacing = 8.0 as CGFloat
+fileprivate let PortalCellVerticalRowSpacing = 8.0 as CGFloat
+fileprivate let PortalCellContainerEdgeSpacing = 16.0 as CGFloat
+
 extension ActiviesViewController: UICollectionViewDelegateFlowLayout {
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return CGSize(width: 200.0, height: 100.0)
+        
+        let width = collectionView.bounds.size.width / 2.0 - (PortalCellCellInternalSpacing/2 + PortalCellContainerEdgeSpacing)
+        return CGSize(width: width, height: 100.0)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
+        return PortalCellVerticalRowSpacing
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        return PortalCellCellInternalSpacing
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+        return UIEdgeInsets(top: 0.0, left: PortalCellContainerEdgeSpacing, bottom: 0.0, right: PortalCellContainerEdgeSpacing)
     }
 }
 

--- a/BackPortal/ViewControllers/ActiviesViewController.swift
+++ b/BackPortal/ViewControllers/ActiviesViewController.swift
@@ -8,6 +8,7 @@ class ActiviesViewController: UICollectionViewController {
     // MARK: Private properties
     
     fileprivate var interventionEvents: [[OCKCarePlanEvent]] = []
+    fileprivate var lastRenderedBounds: CGRect?
     
     
     // MARK: Lifecycle
@@ -26,6 +27,18 @@ class ActiviesViewController: UICollectionViewController {
         }
         
         update(for: patient, on: Date())
+        lastRenderedBounds = collectionView?.bounds
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        
+        guard collectionView?.bounds != lastRenderedBounds else {
+            return
+        }
+        
+        lastRenderedBounds = collectionView?.bounds
+        collectionView?.collectionViewLayout.invalidateLayout()
     }
 }
 

--- a/BackPortal/ViewControllers/ActiviesViewController.swift
+++ b/BackPortal/ViewControllers/ActiviesViewController.swift
@@ -3,12 +3,19 @@ import UIKit
 fileprivate let InterventionActivityReuseIdentifier = "InterventionCell"
 
 class ActiviesViewController: UICollectionViewController {
-    
     // MARK: Lifecycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
         print("[PORTAL] Hello Activies Collection")
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        let patient = patientSplitViewController?.patientListViewController?.selectedPatient
+        
+        print("[PORTAL] Activies Collection Appeared \(patient?.name)")
     }
 }
 

--- a/BackPortal/ViewControllers/ActiviesViewController.swift
+++ b/BackPortal/ViewControllers/ActiviesViewController.swift
@@ -1,0 +1,71 @@
+import UIKit
+
+fileprivate let InterventionActivityReuseIdentifier = "InterventionCell"
+
+class ActiviesViewController: UICollectionViewController {
+    
+    // MARK: Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        print("[PORTAL] Hello Activies Collection")
+    }
+}
+
+extension ActiviesViewController: UICollectionViewDelegateFlowLayout {
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return CGSize(width: 200.0, height: 100.0)
+    }
+}
+
+// MARK: UICollectionViewDataSource
+
+extension ActiviesViewController {
+
+    override func numberOfSections(in collectionView: UICollectionView) -> Int {
+        return 2
+    }
+
+    override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return 5
+    }
+
+    override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: InterventionActivityReuseIdentifier, for: indexPath)
+        return cell
+    }
+}
+
+// MARK: UICollectionViewDelegate
+
+//extension ActiviesViewController {
+    /*
+    // Uncomment this method to specify if the specified item should be highlighted during tracking
+    override func collectionView(_ collectionView: UICollectionView, shouldHighlightItemAt indexPath: IndexPath) -> Bool {
+        return true
+    }
+    */
+
+    /*
+    // Uncomment this method to specify if the specified item should be selected
+    override func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
+        return true
+    }
+    */
+
+    /*
+    // Uncomment these methods to specify if an action menu should be displayed for the specified item, and react to actions performed on the item
+    override func collectionView(_ collectionView: UICollectionView, shouldShowMenuForItemAt indexPath: IndexPath) -> Bool {
+        return false
+    }
+
+    override func collectionView(_ collectionView: UICollectionView, canPerformAction action: Selector, forItemAt indexPath: IndexPath, withSender sender: Any?) -> Bool {
+        return false
+    }
+
+    override func collectionView(_ collectionView: UICollectionView, performAction action: Selector, forItemAt indexPath: IndexPath, withSender sender: Any?) {
+    
+    }
+    */
+//}

--- a/BackPortal/ViewControllers/ActiviesViewController.swift
+++ b/BackPortal/ViewControllers/ActiviesViewController.swift
@@ -52,7 +52,17 @@ extension ActiviesViewController {
 
     override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: InterventionActivityReuseIdentifier, for: indexPath)
-        return cell
+        
+        guard
+            let interventionCell = cell as? InterventionCell,
+            indexPath.row < interventionEvents.count
+        else {
+            return cell
+        }
+        
+        interventionCell.configure(with: interventionEvents[indexPath.row])
+        
+        return interventionCell
     }
 }
 

--- a/BackPortal/ViewControllers/NoSelectionViewController.swift
+++ b/BackPortal/ViewControllers/NoSelectionViewController.swift
@@ -1,0 +1,11 @@
+import UIKit
+
+class NoSelectionViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        print("[PORTAL] Hello No Selection")
+        
+        splitViewController?.preferredDisplayMode = .allVisible
+    }
+}

--- a/BackPortal/ViewControllers/PatientDetailNavController.swift
+++ b/BackPortal/ViewControllers/PatientDetailNavController.swift
@@ -1,0 +1,11 @@
+import UIKit
+
+class PatientDetailNavController: UINavigationController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        print("[PORTAL] Hello Patient Detail Nav")
+        
+        navigationItem.leftItemsSupplementBackButton = true 
+    }
+}

--- a/BackPortal/ViewControllers/PatientDetailViewController.swift
+++ b/BackPortal/ViewControllers/PatientDetailViewController.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+class PatientDetailViewController: UIViewController {
+
+    // MARK: Lifecycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        print("[PORTAL] Hello Patient Detail")
+        
+        navigationItem.leftBarButtonItem = parent?.splitViewController?.displayModeButtonItem
+    }
+}

--- a/BackPortal/ViewControllers/PatientDetailViewController.swift
+++ b/BackPortal/ViewControllers/PatientDetailViewController.swift
@@ -10,4 +10,14 @@ class PatientDetailViewController: UIViewController {
         
         navigationItem.leftBarButtonItem = parent?.splitViewController?.displayModeButtonItem
     }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        if let patientName = patientSplitViewController?.patientListViewController?.selectedPatient?.name {
+            navigationItem.title = patientName
+        } else {
+            navigationItem.title = "Patient"
+        }
+    }
 }

--- a/BackPortal/ViewControllers/PatientListViewController.swift
+++ b/BackPortal/ViewControllers/PatientListViewController.swift
@@ -11,6 +11,16 @@ class PatientListViewController: UITableViewController {
         }
     }
     
+    // MARK: Public Properties
+    
+    var selectedPatient: OCKPatient? {
+        guard let row = tableView?.indexPathForSelectedRow?.row, row < patients.count else {
+            return nil
+        }
+        
+        return patients[row]
+    }
+    
     // MARK: Lifecycle
     
     override func viewDidLoad() {

--- a/BackPortal/ViewControllers/PatientMasterNavController.swift
+++ b/BackPortal/ViewControllers/PatientMasterNavController.swift
@@ -1,0 +1,9 @@
+import UIKit
+
+class PatientMasterNavController: UINavigationController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        print("[PORTAL] Hello Patients Master Nav")
+    }
+}

--- a/BackPortal/ViewControllers/PatientSplitViewController.swift
+++ b/BackPortal/ViewControllers/PatientSplitViewController.swift
@@ -8,3 +8,15 @@ class PatientSplitViewController: UISplitViewController {
 
     }
 }
+
+extension PatientSplitViewController {
+    
+    var patientListViewController: PatientListViewController? {
+        return childViewControllers
+                .flatMap({ $0 as? PatientMasterNavController })
+                .first?
+                .viewControllers
+                .flatMap({ $0 as? PatientListViewController })
+                .first
+    }
+}

--- a/BackPortal/ViewControllers/PatientSplitViewController.swift
+++ b/BackPortal/ViewControllers/PatientSplitViewController.swift
@@ -5,5 +5,6 @@ class PatientSplitViewController: UISplitViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         print("[PORTAL] Hello Patient Split")
+
     }
 }

--- a/BackPortal/ViewControllers/UIViewController+Portal.swift
+++ b/BackPortal/ViewControllers/UIViewController+Portal.swift
@@ -1,0 +1,16 @@
+import UIKit
+
+extension UIViewController {
+    
+    var patientSplitViewController: PatientSplitViewController? {
+        guard let myParent = parent else {
+            return nil
+        }
+        
+        if let split = myParent as? PatientSplitViewController {
+            return split
+        } else {
+            return myParent.patientSplitViewController
+        }
+    }
+}

--- a/BackPortal/Views/Base.lproj/Patients.storyboard
+++ b/BackPortal/Views/Base.lproj/Patients.storyboard
@@ -10,10 +10,26 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
+        <!--Patient Detail Nav Controller-->
+        <scene sceneID="nfg-Nk-Nj0">
+            <objects>
+                <navigationController id="sOB-VH-YDk" customClass="PatientDetailNavController" customModule="BackPortal" customModuleProvider="target" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="MvP-ay-eVU">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="ERB-Ib-2Rx" kind="relationship" relationship="rootViewController" id="2TL-nH-HUY"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="5gP-rf-912" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="49" y="180"/>
+        </scene>
+        <!--Activities-->
         <scene sceneID="Hd8-4K-eui">
             <objects>
-                <viewController id="ERB-Ib-2Rx" sceneMemberID="viewController">
+                <viewController id="ERB-Ib-2Rx" customClass="PatientDetailViewController" customModule="BackPortal" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="gsd-S5-LLr"/>
                         <viewControllerLayoutGuide type="bottom" id="dAv-Wy-m4a"/>
@@ -23,7 +39,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="meJ-oo-LPF">
-                                <rect key="frame" x="0.0" y="20" width="703" height="748"/>
+                                <rect key="frame" x="0.0" y="64" width="703" height="704"/>
                                 <connections>
                                     <segue destination="0eu-cO-tCq" kind="embed" id="W3Z-Mq-a6H"/>
                                 </connections>
@@ -37,10 +53,13 @@
                             <constraint firstItem="dAv-Wy-m4a" firstAttribute="top" secondItem="meJ-oo-LPF" secondAttribute="bottom" id="rhj-I9-nTp"/>
                         </constraints>
                     </view>
+                    <navigationItem key="navigationItem" title="Activities" id="LfF-cN-cgL">
+                        <barButtonItem key="backBarButtonItem" id="SyF-IP-KPf"/>
+                    </navigationItem>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ezo-cS-6BF" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="66" y="152"/>
+            <point key="canvasLocation" x="775" y="180"/>
         </scene>
         <!--Patients-->
         <scene sceneID="U1i-Rb-4jE">
@@ -128,7 +147,7 @@
                     <tabBarItem key="tabBarItem" title="Patients" image="Patients" id="bm1-D0-DaC"/>
                     <connections>
                         <segue destination="R5O-fh-2CA" kind="relationship" relationship="masterViewController" id="QgB-wH-GtN"/>
-                        <segue destination="ERB-Ib-2Rx" kind="relationship" relationship="detailViewController" id="gGG-Nk-ibW"/>
+                        <segue destination="sOB-VH-YDk" kind="relationship" relationship="detailViewController" id="rkd-HM-5Ks"/>
                     </connections>
                 </splitViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="NOf-KA-tD2" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -139,8 +158,8 @@
         <scene sceneID="UPg-2c-7Uc">
             <objects>
                 <collectionViewController id="0eu-cO-tCq" customClass="ActiviesViewController" customModule="BackPortal" customModuleProvider="target" sceneMemberID="viewController">
-                    <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" id="4XY-SU-o9U">
-                        <rect key="frame" x="0.0" y="0.0" width="703" height="748"/>
+                    <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" misplaced="YES" dataMode="prototypes" id="4XY-SU-o9U">
+                        <rect key="frame" x="0.0" y="0.0" width="703" height="704"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="qhC-4l-en9">
@@ -193,7 +212,7 @@
                 </collectionViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="IqY-gK-rah" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="751" y="152"/>
+            <point key="canvasLocation" x="1418" y="205"/>
         </scene>
     </scenes>
     <resources>

--- a/BackPortal/Views/Base.lproj/Patients.storyboard
+++ b/BackPortal/Views/Base.lproj/Patients.storyboard
@@ -26,7 +26,7 @@
             </objects>
             <point key="canvasLocation" x="846" y="180"/>
         </scene>
-        <!--Activities-->
+        <!--Patient Name-->
         <scene sceneID="Hd8-4K-eui">
             <objects>
                 <viewController id="ERB-Ib-2Rx" customClass="PatientDetailViewController" customModule="BackPortal" customModuleProvider="target" sceneMemberID="viewController">
@@ -53,7 +53,7 @@
                             <constraint firstItem="dAv-Wy-m4a" firstAttribute="top" secondItem="meJ-oo-LPF" secondAttribute="bottom" id="rhj-I9-nTp"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" title="Activities" id="LfF-cN-cgL">
+                    <navigationItem key="navigationItem" title="Patient Name" id="LfF-cN-cgL">
                         <barButtonItem key="backBarButtonItem" id="SyF-IP-KPf"/>
                     </navigationItem>
                 </viewController>
@@ -124,10 +124,10 @@
             </objects>
             <point key="canvasLocation" x="846" y="-527"/>
         </scene>
-        <!--Navigation Controller-->
+        <!--Patient Master Nav Controller-->
         <scene sceneID="7E3-Or-qwX">
             <objects>
-                <navigationController id="R5O-fh-2CA" sceneMemberID="viewController">
+                <navigationController id="R5O-fh-2CA" customClass="PatientMasterNavController" customModule="BackPortal" customModuleProvider="target" sceneMemberID="viewController">
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="OvU-bd-bby">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>

--- a/BackPortal/Views/Base.lproj/Patients.storyboard
+++ b/BackPortal/Views/Base.lproj/Patients.storyboard
@@ -211,26 +211,33 @@
                                             <rect key="frame" x="0.0" y="0.0" width="200" height="100"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ypA-Kp-I7c">
-                                                    <rect key="frame" x="20" y="18" width="160" height="24"/>
+                                                    <rect key="frame" x="20" y="15.5" width="160" height="24"/>
                                                     <fontDescription key="fontDescription" type="system" weight="medium" pointSize="20"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Text" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="6y7-EJ-zGK">
-                                                    <rect key="frame" x="20" y="40" width="160" height="17"/>
+                                                    <rect key="frame" x="20" y="37.5" width="160" height="17"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
+                                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="3vQ-nh-Vi5">
+                                                    <rect key="frame" x="20" y="56" width="172" height="36"/>
+                                                </stackView>
                                             </subviews>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <constraints>
                                                 <constraint firstItem="6y7-EJ-zGK" firstAttribute="top" secondItem="ypA-Kp-I7c" secondAttribute="bottom" constant="-2" id="9OE-ih-gTi"/>
-                                                <constraint firstItem="ypA-Kp-I7c" firstAttribute="centerY" secondItem="6dP-Ky-jCT" secondAttribute="centerY" multiplier="3/5" id="Nce-vB-qXE"/>
+                                                <constraint firstAttribute="bottom" secondItem="3vQ-nh-Vi5" secondAttribute="bottom" constant="8" id="Faj-v2-fcS"/>
+                                                <constraint firstItem="3vQ-nh-Vi5" firstAttribute="top" secondItem="6y7-EJ-zGK" secondAttribute="bottom" constant="2" id="H7I-pe-iDK"/>
+                                                <constraint firstAttribute="trailing" secondItem="3vQ-nh-Vi5" secondAttribute="trailing" constant="8" id="N7P-vF-J7V"/>
+                                                <constraint firstItem="ypA-Kp-I7c" firstAttribute="centerY" secondItem="6dP-Ky-jCT" secondAttribute="centerY" multiplier="55/100" id="Nce-vB-qXE"/>
                                                 <constraint firstItem="6y7-EJ-zGK" firstAttribute="leading" secondItem="ypA-Kp-I7c" secondAttribute="leading" id="XGc-h4-Ia6"/>
                                                 <constraint firstAttribute="trailing" secondItem="ypA-Kp-I7c" secondAttribute="trailing" constant="20" symbolic="YES" id="Xvd-lv-GbK"/>
                                                 <constraint firstItem="ypA-Kp-I7c" firstAttribute="leading" secondItem="6dP-Ky-jCT" secondAttribute="leading" constant="20" symbolic="YES" id="m4r-mC-Jl2"/>
                                                 <constraint firstItem="6y7-EJ-zGK" firstAttribute="trailing" secondItem="ypA-Kp-I7c" secondAttribute="trailing" id="mFP-Lz-Gmx"/>
+                                                <constraint firstItem="3vQ-nh-Vi5" firstAttribute="leading" secondItem="6y7-EJ-zGK" secondAttribute="leading" id="xEt-eu-Yke"/>
                                             </constraints>
                                         </view>
                                     </subviews>
@@ -243,6 +250,7 @@
                                 </constraints>
                                 <size key="customSize" width="200" height="100"/>
                                 <connections>
+                                    <outlet property="eventsStackView" destination="3vQ-nh-Vi5" id="g12-Vb-Rhn"/>
                                     <outlet property="nameLabel" destination="ypA-Kp-I7c" id="dNp-4w-HKN"/>
                                     <outlet property="subLabel" destination="6y7-EJ-zGK" id="epz-g5-F8F"/>
                                 </connections>
@@ -256,7 +264,7 @@
                 </collectionViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="IqY-gK-rah" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2183" y="205"/>
+            <point key="canvasLocation" x="2182.91015625" y="204.6875"/>
         </scene>
     </scenes>
     <resources>

--- a/BackPortal/Views/Base.lproj/Patients.storyboard
+++ b/BackPortal/Views/Base.lproj/Patients.storyboard
@@ -193,7 +193,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="702.5" height="704"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                        <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="qhC-4l-en9">
+                        <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" id="qhC-4l-en9">
                             <size key="itemSize" width="200" height="100"/>
                             <size key="headerReferenceSize" width="0.0" height="0.0"/>
                             <size key="footerReferenceSize" width="0.0" height="0.0"/>

--- a/BackPortal/Views/Base.lproj/Patients.storyboard
+++ b/BackPortal/Views/Base.lproj/Patients.storyboard
@@ -39,7 +39,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="meJ-oo-LPF">
-                                <rect key="frame" x="0.0" y="64" width="703" height="704"/>
+                                <rect key="frame" x="0.0" y="64" width="702.5" height="704"/>
                                 <connections>
                                     <segue destination="0eu-cO-tCq" kind="embed" id="W3Z-Mq-a6H"/>
                                 </connections>
@@ -189,8 +189,8 @@
         <scene sceneID="UPg-2c-7Uc">
             <objects>
                 <collectionViewController id="0eu-cO-tCq" customClass="ActiviesViewController" customModule="BackPortal" customModuleProvider="target" sceneMemberID="viewController">
-                    <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" misplaced="YES" dataMode="prototypes" id="4XY-SU-o9U">
-                        <rect key="frame" x="0.0" y="0.0" width="703" height="704"/>
+                    <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" id="4XY-SU-o9U">
+                        <rect key="frame" x="0.0" y="0.0" width="702.5" height="704"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="qhC-4l-en9">
@@ -200,7 +200,7 @@
                             <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                         </collectionViewFlowLayout>
                         <cells>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="InterventionCell" id="vGn-ne-mFl">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="InterventionCell" id="vGn-ne-mFl" customClass="InterventionCell" customModule="BackPortal" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="0.0" width="200" height="100"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -233,6 +233,9 @@
                                     <constraint firstAttribute="bottom" secondItem="6dP-Ky-jCT" secondAttribute="bottom" id="ivO-gM-UjU"/>
                                 </constraints>
                                 <size key="customSize" width="200" height="100"/>
+                                <connections>
+                                    <outlet property="nameLabel" destination="ypA-Kp-I7c" id="dNp-4w-HKN"/>
+                                </connections>
                             </collectionViewCell>
                         </cells>
                         <connections>

--- a/BackPortal/Views/Base.lproj/Patients.storyboard
+++ b/BackPortal/Views/Base.lproj/Patients.storyboard
@@ -189,10 +189,10 @@
         <scene sceneID="UPg-2c-7Uc">
             <objects>
                 <collectionViewController id="0eu-cO-tCq" customClass="ActiviesViewController" customModule="BackPortal" customModuleProvider="target" sceneMemberID="viewController">
-                    <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" id="4XY-SU-o9U">
+                    <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" misplaced="YES" dataMode="prototypes" id="4XY-SU-o9U">
                         <rect key="frame" x="0.0" y="0.0" width="702.5" height="704"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" id="qhC-4l-en9">
                             <size key="itemSize" width="200" height="100"/>
                             <size key="headerReferenceSize" width="0.0" height="0.0"/>
@@ -210,18 +210,27 @@
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6dP-Ky-jCT" userLabel="Content View">
                                             <rect key="frame" x="0.0" y="0.0" width="200" height="100"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hello" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ypA-Kp-I7c">
-                                                    <rect key="frame" x="20" y="40" width="160" height="21"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ypA-Kp-I7c">
+                                                    <rect key="frame" x="20" y="18" width="160" height="24"/>
+                                                    <fontDescription key="fontDescription" type="system" weight="medium" pointSize="20"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Text" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="6y7-EJ-zGK">
+                                                    <rect key="frame" x="20" y="40" width="160" height="17"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
                                             </subviews>
-                                            <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <constraints>
-                                                <constraint firstItem="ypA-Kp-I7c" firstAttribute="centerY" secondItem="6dP-Ky-jCT" secondAttribute="centerY" id="Nce-vB-qXE"/>
+                                                <constraint firstItem="6y7-EJ-zGK" firstAttribute="top" secondItem="ypA-Kp-I7c" secondAttribute="bottom" constant="-2" id="9OE-ih-gTi"/>
+                                                <constraint firstItem="ypA-Kp-I7c" firstAttribute="centerY" secondItem="6dP-Ky-jCT" secondAttribute="centerY" multiplier="3/5" id="Nce-vB-qXE"/>
+                                                <constraint firstItem="6y7-EJ-zGK" firstAttribute="leading" secondItem="ypA-Kp-I7c" secondAttribute="leading" id="XGc-h4-Ia6"/>
                                                 <constraint firstAttribute="trailing" secondItem="ypA-Kp-I7c" secondAttribute="trailing" constant="20" symbolic="YES" id="Xvd-lv-GbK"/>
                                                 <constraint firstItem="ypA-Kp-I7c" firstAttribute="leading" secondItem="6dP-Ky-jCT" secondAttribute="leading" constant="20" symbolic="YES" id="m4r-mC-Jl2"/>
+                                                <constraint firstItem="6y7-EJ-zGK" firstAttribute="trailing" secondItem="ypA-Kp-I7c" secondAttribute="trailing" id="mFP-Lz-Gmx"/>
                                             </constraints>
                                         </view>
                                     </subviews>
@@ -235,6 +244,7 @@
                                 <size key="customSize" width="200" height="100"/>
                                 <connections>
                                     <outlet property="nameLabel" destination="ypA-Kp-I7c" id="dNp-4w-HKN"/>
+                                    <outlet property="subLabel" destination="6y7-EJ-zGK" id="epz-g5-F8F"/>
                                 </connections>
                             </collectionViewCell>
                         </cells>

--- a/BackPortal/Views/Base.lproj/Patients.storyboard
+++ b/BackPortal/Views/Base.lproj/Patients.storyboard
@@ -24,7 +24,7 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="5gP-rf-912" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="49" y="180"/>
+            <point key="canvasLocation" x="846" y="180"/>
         </scene>
         <!--Activities-->
         <scene sceneID="Hd8-4K-eui">
@@ -59,7 +59,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ezo-cS-6BF" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="775" y="180"/>
+            <point key="canvasLocation" x="1549" y="180"/>
         </scene>
         <!--Patients-->
         <scene sceneID="U1i-Rb-4jE">
@@ -102,6 +102,7 @@
                                 <connections>
                                     <outlet property="emailLabel" destination="olY-vH-efG" id="MPM-qP-QGu"/>
                                     <outlet property="nameLabel" destination="9x8-Zt-O7g" id="q64-Uy-UvN"/>
+                                    <segue destination="sOB-VH-YDk" kind="showDetail" id="Nxb-0S-IS8"/>
                                 </connections>
                             </tableViewCell>
                         </prototypes>
@@ -140,6 +141,36 @@
             </objects>
             <point key="canvasLocation" x="49" y="-527"/>
         </scene>
+        <!--No Selection View Controller-->
+        <scene sceneID="fFy-7d-w2E">
+            <objects>
+                <viewController id="M9U-A2-3ko" customClass="NoSelectionViewController" customModule="BackPortal" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="QBL-eW-rDV"/>
+                        <viewControllerLayoutGuide type="bottom" id="BeB-ec-cwn"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="DXD-Dy-3ec">
+                        <rect key="frame" x="0.0" y="0.0" width="703" height="768"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Select a Patient" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZnW-wL-jc5">
+                                <rect key="frame" x="255.5" y="367.5" width="192.5" height="33.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="28"/>
+                                <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="ZnW-wL-jc5" firstAttribute="centerY" secondItem="DXD-Dy-3ec" secondAttribute="centerY" id="JXh-fo-fdO"/>
+                            <constraint firstItem="ZnW-wL-jc5" firstAttribute="centerX" secondItem="DXD-Dy-3ec" secondAttribute="centerX" id="ikN-TM-tr0"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="nwt-D3-Seh" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="49" y="329"/>
+        </scene>
         <!--Patients-->
         <scene sceneID="e5b-1M-bZU">
             <objects>
@@ -147,7 +178,7 @@
                     <tabBarItem key="tabBarItem" title="Patients" image="Patients" id="bm1-D0-DaC"/>
                     <connections>
                         <segue destination="R5O-fh-2CA" kind="relationship" relationship="masterViewController" id="QgB-wH-GtN"/>
-                        <segue destination="sOB-VH-YDk" kind="relationship" relationship="detailViewController" id="rkd-HM-5Ks"/>
+                        <segue destination="M9U-A2-3ko" kind="relationship" relationship="detailViewController" id="cD4-yJ-Nta"/>
                     </connections>
                 </splitViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="NOf-KA-tD2" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -212,7 +243,7 @@
                 </collectionViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="IqY-gK-rah" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1418" y="205"/>
+            <point key="canvasLocation" x="2183" y="205"/>
         </scene>
     </scenes>
     <resources>

--- a/BackPortal/Views/Base.lproj/Patients.storyboard
+++ b/BackPortal/Views/Base.lproj/Patients.storyboard
@@ -21,12 +21,26 @@
                     <view key="view" contentMode="scaleToFill" id="YOJ-F2-74r">
                         <rect key="frame" x="0.0" y="0.0" width="703" height="768"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="meJ-oo-LPF">
+                                <rect key="frame" x="0.0" y="20" width="703" height="748"/>
+                                <connections>
+                                    <segue destination="0eu-cO-tCq" kind="embed" id="W3Z-Mq-a6H"/>
+                                </connections>
+                            </containerView>
+                        </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstAttribute="trailing" secondItem="meJ-oo-LPF" secondAttribute="trailing" id="FxK-JQ-88e"/>
+                            <constraint firstItem="meJ-oo-LPF" firstAttribute="leading" secondItem="YOJ-F2-74r" secondAttribute="leading" id="UnE-Cj-wHs"/>
+                            <constraint firstItem="meJ-oo-LPF" firstAttribute="top" secondItem="gsd-S5-LLr" secondAttribute="bottom" id="fvq-nG-pJt"/>
+                            <constraint firstItem="dAv-Wy-m4a" firstAttribute="top" secondItem="meJ-oo-LPF" secondAttribute="bottom" id="rhj-I9-nTp"/>
+                        </constraints>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ezo-cS-6BF" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="49" y="128"/>
+            <point key="canvasLocation" x="66" y="152"/>
         </scene>
         <!--Patients-->
         <scene sceneID="U1i-Rb-4jE">
@@ -120,6 +134,66 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="NOf-KA-tD2" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-734" y="-134"/>
+        </scene>
+        <!--Activies View Controller-->
+        <scene sceneID="UPg-2c-7Uc">
+            <objects>
+                <collectionViewController id="0eu-cO-tCq" customClass="ActiviesViewController" customModule="BackPortal" customModuleProvider="target" sceneMemberID="viewController">
+                    <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" id="4XY-SU-o9U">
+                        <rect key="frame" x="0.0" y="0.0" width="703" height="748"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="qhC-4l-en9">
+                            <size key="itemSize" width="200" height="100"/>
+                            <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                            <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                            <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                        </collectionViewFlowLayout>
+                        <cells>
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="InterventionCell" id="vGn-ne-mFl">
+                                <rect key="frame" x="0.0" y="0.0" width="200" height="100"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                                    <rect key="frame" x="0.0" y="0.0" width="200" height="100"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6dP-Ky-jCT" userLabel="Content View">
+                                            <rect key="frame" x="0.0" y="0.0" width="200" height="100"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hello" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ypA-Kp-I7c">
+                                                    <rect key="frame" x="20" y="40" width="160" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                            <constraints>
+                                                <constraint firstItem="ypA-Kp-I7c" firstAttribute="centerY" secondItem="6dP-Ky-jCT" secondAttribute="centerY" id="Nce-vB-qXE"/>
+                                                <constraint firstAttribute="trailing" secondItem="ypA-Kp-I7c" secondAttribute="trailing" constant="20" symbolic="YES" id="Xvd-lv-GbK"/>
+                                                <constraint firstItem="ypA-Kp-I7c" firstAttribute="leading" secondItem="6dP-Ky-jCT" secondAttribute="leading" constant="20" symbolic="YES" id="m4r-mC-Jl2"/>
+                                            </constraints>
+                                        </view>
+                                    </subviews>
+                                </view>
+                                <constraints>
+                                    <constraint firstAttribute="trailing" secondItem="6dP-Ky-jCT" secondAttribute="trailing" id="2zd-hB-0ne"/>
+                                    <constraint firstItem="6dP-Ky-jCT" firstAttribute="top" secondItem="vGn-ne-mFl" secondAttribute="top" id="8bq-ka-cTX"/>
+                                    <constraint firstItem="6dP-Ky-jCT" firstAttribute="leading" secondItem="vGn-ne-mFl" secondAttribute="leading" id="Hl3-bk-2QM"/>
+                                    <constraint firstAttribute="bottom" secondItem="6dP-Ky-jCT" secondAttribute="bottom" id="ivO-gM-UjU"/>
+                                </constraints>
+                                <size key="customSize" width="200" height="100"/>
+                            </collectionViewCell>
+                        </cells>
+                        <connections>
+                            <outlet property="dataSource" destination="0eu-cO-tCq" id="Z4k-zh-Wjj"/>
+                            <outlet property="delegate" destination="0eu-cO-tCq" id="Fqc-Yz-mYn"/>
+                        </connections>
+                    </collectionView>
+                </collectionViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="IqY-gK-rah" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="751" y="152"/>
         </scene>
     </scenes>
     <resources>

--- a/BackPortal/Views/InterventionCell.swift
+++ b/BackPortal/Views/InterventionCell.swift
@@ -1,6 +1,8 @@
 import UIKit
 import CareKit
 
+typealias InterventionEventTapCallback = (OCKCarePlanEvent) -> Void
+
 class InterventionCell: UICollectionViewCell {
     
     // MARK: Outlets
@@ -11,12 +13,14 @@ class InterventionCell: UICollectionViewCell {
     
     // MARK: Private Properties
     
-    private var events: [OCKCarePlanEvent] = []
+    fileprivate var events: [OCKCarePlanEvent] = []
+    fileprivate var tapCallback: InterventionEventTapCallback? = nil
     
     // MARK: Public
     
-    func configure(with eventList: [OCKCarePlanEvent]) {
+    func configure(with eventList: [OCKCarePlanEvent], tapBack: InterventionEventTapCallback?) {
         self.events = eventList
+        self.tapCallback = tapBack
         
         guard let activity = events.first?.activity else {
             return
@@ -72,7 +76,11 @@ fileprivate extension InterventionCell {
     }
     
     @objc func didPress(eventButton: UIButton) {
-        print("[PORTAL] Did Press Event Occurrence: \(eventButton.tag)")
+        guard eventButton.tag < events.count else {
+            return
+        }
+        
+        tapCallback?(events[eventButton.tag])
     }
     
     func resetStackView() {

--- a/BackPortal/Views/InterventionCell.swift
+++ b/BackPortal/Views/InterventionCell.swift
@@ -6,6 +6,7 @@ class InterventionCell: UICollectionViewCell {
     // MARK: Outlets
     
     @IBOutlet fileprivate var nameLabel: UILabel?
+    @IBOutlet fileprivate var subLabel: UILabel?
     
     // MARK: Public
     
@@ -15,7 +16,10 @@ class InterventionCell: UICollectionViewCell {
         }
         
         onMain {
+            self.layer.cornerRadius = 6.0
+            
             self.nameLabel?.text = activity.title
+            self.subLabel?.text = activity.text
         }
     }
 }

--- a/BackPortal/Views/InterventionCell.swift
+++ b/BackPortal/Views/InterventionCell.swift
@@ -1,0 +1,21 @@
+import UIKit
+import CareKit
+
+class InterventionCell: UICollectionViewCell {
+    
+    // MARK: Outlets
+    
+    @IBOutlet fileprivate var nameLabel: UILabel?
+    
+    // MARK: Public
+    
+    func configure(with events: [OCKCarePlanEvent]) {
+        guard let activity = events.first?.activity else {
+            return
+        }
+        
+        onMain {
+            self.nameLabel?.text = activity.title
+        }
+    }
+}

--- a/BackPortal/Views/InterventionCell.swift
+++ b/BackPortal/Views/InterventionCell.swift
@@ -9,9 +9,15 @@ class InterventionCell: UICollectionViewCell {
     @IBOutlet fileprivate var subLabel: UILabel?
     @IBOutlet fileprivate var eventsStackView: UIStackView?
     
+    // MARK: Private Properties
+    
+    private var events: [OCKCarePlanEvent] = []
+    
     // MARK: Public
     
-    func configure(with events: [OCKCarePlanEvent]) {
+    func configure(with eventList: [OCKCarePlanEvent]) {
+        self.events = eventList
+        
         guard let activity = events.first?.activity else {
             return
         }
@@ -24,23 +30,9 @@ class InterventionCell: UICollectionViewCell {
             self.nameLabel?.text = activity.title
             self.subLabel?.text = activity.text
             
-            events.forEach { event in
-                let view = UIView()
-                
-                let size = (self.eventsStackView?.bounds.height ?? 36.0)
-                view.heightAnchor.constraint(equalToConstant: size).isActive = true
-                view.widthAnchor.constraint(equalToConstant: size).isActive = true
-                
-                view.layer.borderWidth = 2.0
-                view.layer.borderColor = activity.tintColor?.cgColor
-                view.layer.cornerRadius = size / 2.0
-                
-                if case .completed = event.state {
-                    view.backgroundColor = activity.tintColor
-                }
-                
-                self.eventsStackView?.addArrangedSubview(view)
-                print("[PORTAL] View Height: \(view.bounds.height)")
+            self.events.forEach { event in
+                let button = self.button(for: event, color: activity.tintColor)
+                self.eventsStackView?.addArrangedSubview(button)
             }
             
             let spaceView = UIView()
@@ -52,8 +44,36 @@ class InterventionCell: UICollectionViewCell {
             self.eventsStackView?.addArrangedSubview(spaceView)
         }
     }
+}
+
+// MARK: Private
+
+fileprivate extension InterventionCell {
     
-    // MARK: Private
+    func button(for event: OCKCarePlanEvent, color tintColor: UIColor?) -> UIButton {
+        let button = UIButton()
+        
+        button.tag = Int(event.occurrenceIndexOfDay)
+        button.addTarget(self, action: #selector(self.didPress(eventButton:)), for: .touchUpInside)
+        
+        let size = (self.eventsStackView?.bounds.height ?? 36.0)
+        button.heightAnchor.constraint(equalToConstant: size).isActive = true
+        button.widthAnchor.constraint(equalToConstant: size).isActive = true
+        
+        button.layer.borderWidth = 2.0
+        button.layer.borderColor = tintColor?.cgColor
+        button.layer.cornerRadius = size / 2.0
+        
+        if case .completed = event.state {
+            button.backgroundColor = tintColor
+        }
+        
+        return button
+    }
+    
+    @objc func didPress(eventButton: UIButton) {
+        print("[PORTAL] Did Press Event Occurrence: \(eventButton.tag)")
+    }
     
     func resetStackView() {
         guard let eventsStackView = eventsStackView else {

--- a/BackPortal/Views/InterventionCell.swift
+++ b/BackPortal/Views/InterventionCell.swift
@@ -7,6 +7,7 @@ class InterventionCell: UICollectionViewCell {
     
     @IBOutlet fileprivate var nameLabel: UILabel?
     @IBOutlet fileprivate var subLabel: UILabel?
+    @IBOutlet fileprivate var eventsStackView: UIStackView?
     
     // MARK: Public
     
@@ -16,10 +17,52 @@ class InterventionCell: UICollectionViewCell {
         }
         
         onMain {
+            self.resetStackView()
+            
             self.layer.cornerRadius = 6.0
             
             self.nameLabel?.text = activity.title
             self.subLabel?.text = activity.text
+            
+            events.forEach { event in
+                let view = UIView()
+                
+                let size = (self.eventsStackView?.bounds.height ?? 36.0)
+                view.heightAnchor.constraint(equalToConstant: size).isActive = true
+                view.widthAnchor.constraint(equalToConstant: size).isActive = true
+                
+                view.layer.borderWidth = 2.0
+                view.layer.borderColor = activity.tintColor?.cgColor
+                view.layer.cornerRadius = size / 2.0
+                
+                if case .completed = event.state {
+                    view.backgroundColor = activity.tintColor
+                }
+                
+                self.eventsStackView?.addArrangedSubview(view)
+                print("[PORTAL] View Height: \(view.bounds.height)")
+            }
+            
+            let spaceView = UIView()
+            let size = (self.eventsStackView?.bounds.height ?? 36.0)
+            spaceView.heightAnchor.constraint(equalToConstant: size).isActive = true
+            spaceView.widthAnchor.constraint(greaterThanOrEqualToConstant: size).isActive = true
+            spaceView.backgroundColor = UIColor.clear
+            
+            self.eventsStackView?.addArrangedSubview(spaceView)
+        }
+    }
+    
+    // MARK: Private
+    
+    func resetStackView() {
+        guard let eventsStackView = eventsStackView else {
+            return
+        }
+        
+        while eventsStackView.arrangedSubviews.count > 0 {
+            eventsStackView.arrangedSubviews[0].removeFromSuperview()
+            //eventsStackView.removeArrangedSubview(eventsStackView.arrangedSubviews[0])
         }
     }
 }


### PR DESCRIPTION
When the user selects a patient, the detail controller displays a collection view of each Intervention Activity the patient has to complete. Currently, it only displays for the current date. The activities include CareKit-style indicators as to which events have been completed, and allow the user to tap any event and toggle it's status for the patient. The updated data is automagically pushed to CloudMine by CMHealth.