### PR TITLE
Display Assessment Activities and Allow Updating their Events

### DIFF
--- a/BackPortal.xcodeproj/project.pbxproj
+++ b/BackPortal.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		B45316571EF84D46004A8FD9 /* UIViewController+Portal.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45316561EF84D46004A8FD9 /* UIViewController+Portal.swift */; };
 		B45316591EF84F87004A8FD9 /* PatientMasterNavController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45316581EF84F87004A8FD9 /* PatientMasterNavController.swift */; };
 		B453165B1EF97A7D004A8FD9 /* InterventionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B453165A1EF97A7D004A8FD9 /* InterventionCell.swift */; };
+		B46FEA1B1EFB03C900F9D09E /* AssessmentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46FEA1A1EFB03C900F9D09E /* AssessmentCell.swift */; };
 		B4C2BE1C1EF823D200E70A31 /* ActiviesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C2BE1B1EF823D200E70A31 /* ActiviesViewController.swift */; };
 		B4C2BE1E1EF8328100E70A31 /* PatientDetailNavController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C2BE1D1EF8328100E70A31 /* PatientDetailNavController.swift */; };
 		E3E647F8FB412EE4983BFCCF /* Pods_BackPortalUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B9CB4F026613D1FC355F9B5 /* Pods_BackPortalUITests.framework */; };
@@ -92,6 +93,7 @@
 		B45316561EF84D46004A8FD9 /* UIViewController+Portal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+Portal.swift"; sourceTree = "<group>"; };
 		B45316581EF84F87004A8FD9 /* PatientMasterNavController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatientMasterNavController.swift; sourceTree = "<group>"; };
 		B453165A1EF97A7D004A8FD9 /* InterventionCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterventionCell.swift; sourceTree = "<group>"; };
+		B46FEA1A1EFB03C900F9D09E /* AssessmentCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssessmentCell.swift; sourceTree = "<group>"; };
 		B4C2BE1B1EF823D200E70A31 /* ActiviesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActiviesViewController.swift; sourceTree = "<group>"; };
 		B4C2BE1D1EF8328100E70A31 /* PatientDetailNavController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatientDetailNavController.swift; sourceTree = "<group>"; };
 		B7D0E29578B809FC4C0276D6 /* Pods-BackPortalTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BackPortalTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-BackPortalTests/Pods-BackPortalTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -234,6 +236,7 @@
 				B41DC02D1EF324E500B7DAE9 /* Patients.storyboard */,
 				B41DC0321EF3306900B7DAE9 /* PatientCell.swift */,
 				B453165A1EF97A7D004A8FD9 /* InterventionCell.swift */,
+				B46FEA1A1EFB03C900F9D09E /* AssessmentCell.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -557,6 +560,7 @@
 				B4C2BE1E1EF8328100E70A31 /* PatientDetailNavController.swift in Sources */,
 				B41DC0181EF2DF5900B7DAE9 /* AuthViewController.swift in Sources */,
 				B41DC00F1EF2D9CC00B7DAE9 /* PortalSecrets.swift in Sources */,
+				B46FEA1B1EFB03C900F9D09E /* AssessmentCell.swift in Sources */,
 				B45316591EF84F87004A8FD9 /* PatientMasterNavController.swift in Sources */,
 				B41DC0331EF3306900B7DAE9 /* PatientCell.swift in Sources */,
 				B41DC0161EF2DE3D00B7DAE9 /* DispatchUtils.swift in Sources */,

--- a/BackPortal.xcodeproj/project.pbxproj
+++ b/BackPortal.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		B45316591EF84F87004A8FD9 /* PatientMasterNavController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45316581EF84F87004A8FD9 /* PatientMasterNavController.swift */; };
 		B453165B1EF97A7D004A8FD9 /* InterventionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B453165A1EF97A7D004A8FD9 /* InterventionCell.swift */; };
 		B46FEA1B1EFB03C900F9D09E /* AssessmentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46FEA1A1EFB03C900F9D09E /* AssessmentCell.swift */; };
+		B46FEA1E1EFC15C100F9D09E /* AssessmentTasks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46FEA1D1EFC15C100F9D09E /* AssessmentTasks.swift */; };
 		B4C2BE1C1EF823D200E70A31 /* ActiviesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C2BE1B1EF823D200E70A31 /* ActiviesViewController.swift */; };
 		B4C2BE1E1EF8328100E70A31 /* PatientDetailNavController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C2BE1D1EF8328100E70A31 /* PatientDetailNavController.swift */; };
 		E3E647F8FB412EE4983BFCCF /* Pods_BackPortalUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B9CB4F026613D1FC355F9B5 /* Pods_BackPortalUITests.framework */; };
@@ -94,6 +95,7 @@
 		B45316581EF84F87004A8FD9 /* PatientMasterNavController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatientMasterNavController.swift; sourceTree = "<group>"; };
 		B453165A1EF97A7D004A8FD9 /* InterventionCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterventionCell.swift; sourceTree = "<group>"; };
 		B46FEA1A1EFB03C900F9D09E /* AssessmentCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssessmentCell.swift; sourceTree = "<group>"; };
+		B46FEA1D1EFC15C100F9D09E /* AssessmentTasks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssessmentTasks.swift; sourceTree = "<group>"; };
 		B4C2BE1B1EF823D200E70A31 /* ActiviesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActiviesViewController.swift; sourceTree = "<group>"; };
 		B4C2BE1D1EF8328100E70A31 /* PatientDetailNavController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatientDetailNavController.swift; sourceTree = "<group>"; };
 		B7D0E29578B809FC4C0276D6 /* Pods-BackPortalTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BackPortalTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-BackPortalTests/Pods-BackPortalTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -189,6 +191,7 @@
 		B4297EDB1EF2D1D300A0DE1F /* BackPortal */ = {
 			isa = PBXGroup;
 			children = (
+				B46FEA1C1EFC15A400F9D09E /* Models */,
 				B4297F0B1EF2D41F00A0DE1F /* Views */,
 				B4297F1B1EF2D61D00A0DE1F /* ViewControllers */,
 				B41DC00D1EF2D9A000B7DAE9 /* Lib */,
@@ -258,6 +261,14 @@
 				B4C2BE1B1EF823D200E70A31 /* ActiviesViewController.swift */,
 			);
 			path = ViewControllers;
+			sourceTree = "<group>";
+		};
+		B46FEA1C1EFC15A400F9D09E /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				B46FEA1D1EFC15C100F9D09E /* AssessmentTasks.swift */,
+			);
+			path = Models;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -558,6 +569,7 @@
 				B41DC01A1EF2E3F200B7DAE9 /* AlertUtils.swift in Sources */,
 				B41DC0211EF2FB6500B7DAE9 /* MainPanelViewController.swift in Sources */,
 				B4C2BE1E1EF8328100E70A31 /* PatientDetailNavController.swift in Sources */,
+				B46FEA1E1EFC15C100F9D09E /* AssessmentTasks.swift in Sources */,
 				B41DC0181EF2DF5900B7DAE9 /* AuthViewController.swift in Sources */,
 				B41DC00F1EF2D9CC00B7DAE9 /* PortalSecrets.swift in Sources */,
 				B46FEA1B1EFB03C900F9D09E /* AssessmentCell.swift in Sources */,

--- a/BackPortal/Models/AssessmentTasks.swift
+++ b/BackPortal/Models/AssessmentTasks.swift
@@ -1,0 +1,58 @@
+import ResearchKit
+
+struct AssessmentTasks {
+    
+    static var PainIdentifier = "BCMPainTrack"
+    
+    static var PainTask: ORKOrderedTask {
+        let painScale = ORKScaleAnswerFormat(maximumValue: 10, minimumValue: 1, defaultValue: 5, step: 1)
+        let painQuestion = ORKQuestionStep(identifier: PainIdentifier,
+                                           title: "How did the patient rate their pain today?",
+                                           text: "Where 1 is no pain and 10 is the worst pain imaginable",
+                                           answer: painScale)
+        painQuestion.isOptional = false
+        
+        return ORKOrderedTask(identifier: PainIdentifier, steps: [painQuestion])
+    }
+    
+    static var MoodIdentifier = "BCMMoodTrack"
+    
+    static var MoodTask: ORKOrderedTask {
+        let moodScale = ORKScaleAnswerFormat(maximumValue: 10, minimumValue: 1, defaultValue: 5, step: 1)
+        let moodQuestion = ORKQuestionStep(identifier: MoodIdentifier,
+                                           title: NSLocalizedString("How is the patient's mood today?", comment: ""),
+                                           text: NSLocalizedString("Where 1 is very poor and 10 very good", comment: ""),
+                                           answer: moodScale)
+        moodQuestion.isOptional = false
+        
+        return ORKOrderedTask(identifier: MoodIdentifier, steps: [moodQuestion])
+    }
+    
+    static var WeightIdentifier = "BCMWeightTrack"
+    
+    static var WeightTask: ORKOrderedTask {
+        let weightAnswer = ORKNumericAnswerFormat(style: .decimal,
+                                                  unit: NSLocalizedString("lbs", comment: ""),
+                                                  minimum: NSNumber(value: 50),
+                                                  maximum: NSNumber(value: 500))
+        let weightQuestion = ORKQuestionStep(identifier: WeightIdentifier,
+                                             title: NSLocalizedString("Weight", comment: ""),
+                                             answer: weightAnswer)
+        weightQuestion.isOptional = false
+        
+        return ORKOrderedTask(identifier: WeightIdentifier, steps: [weightQuestion])
+    }
+    
+    static func taskFor(identifier activityId: String) -> ORKTask? {
+        switch activityId {
+        case WeightIdentifier:
+            return AssessmentTasks.WeightTask
+        case PainIdentifier:
+            return AssessmentTasks.PainTask
+        case MoodIdentifier:
+            return AssessmentTasks.MoodTask
+        default:
+            return nil
+        }
+    }
+}

--- a/BackPortal/ViewControllers/ActiviesViewController.swift
+++ b/BackPortal/ViewControllers/ActiviesViewController.swift
@@ -2,6 +2,7 @@ import UIKit
 import CareKit.NSDateComponents_CarePlan
 
 fileprivate let InterventionActivityReuseIdentifier = "InterventionCell"
+fileprivate let AssessmentActivityReuseIdentifier = "AssessmentCell"
 
 class ActiviesViewController: UICollectionViewController {
     
@@ -71,30 +72,23 @@ extension ActiviesViewController: UICollectionViewDelegateFlowLayout {
 extension ActiviesViewController {
 
     override func numberOfSections(in collectionView: UICollectionView) -> Int {
-        return 1
+        return 2
     }
 
     override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return interventionEvents.count
+        switch section {
+        case 0: return interventionEvents.count
+        case 1: return assessmentEvents.count
+        default: return 0
+        }
     }
 
     override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: InterventionActivityReuseIdentifier, for: indexPath)
-        
-        guard
-            let interventionCell = cell as? InterventionCell,
-            indexPath.row < interventionEvents.count
-        else {
-            return cell
+        switch indexPath.section {
+        case 0: return interventionCell(from: collectionView, at: indexPath)
+        case 1: return assessmentCell(from: collectionView, at: indexPath)
+        default: fatalError()
         }
-        
-        interventionCell.configure(with: interventionEvents[indexPath.row]) { [weak self] event in
-            print("[PORTAL] Callback for event with occurrence: \(event.occurrenceIndexOfDay)")
-            
-            self?.toggle(interventionEvent: event)
-        }
-        
-        return interventionCell
     }
 }
 
@@ -151,6 +145,30 @@ fileprivate extension ActiviesViewController {
             
             self?.updateData(on: Date())
         }
+    }
+    
+    func interventionCell(from collectionView: UICollectionView, at indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: InterventionActivityReuseIdentifier, for: indexPath)
+        
+        guard
+            let interventionCell = cell as? InterventionCell,
+            indexPath.row < interventionEvents.count
+        else {
+                return cell
+        }
+        
+        interventionCell.configure(with: interventionEvents[indexPath.row]) { [weak self] event in
+            print("[PORTAL] Callback for event with occurrence: \(event.occurrenceIndexOfDay)")
+            
+            self?.toggle(interventionEvent: event)
+        }
+        
+        return interventionCell
+    }
+    
+    func assessmentCell(from collectionView: UICollectionView, at indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: AssessmentActivityReuseIdentifier, for: indexPath)
+        return cell
     }
 }
 

--- a/BackPortal/ViewControllers/ActiviesViewController.swift
+++ b/BackPortal/ViewControllers/ActiviesViewController.swift
@@ -168,7 +168,17 @@ fileprivate extension ActiviesViewController {
     
     func assessmentCell(from collectionView: UICollectionView, at indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: AssessmentActivityReuseIdentifier, for: indexPath)
-        return cell
+        
+        guard
+            let assessmentCell = cell as? AssessmentCell,
+            indexPath.row < assessmentEvents.count
+        else {
+            return cell
+        }
+        
+        assessmentCell.configure(with: assessmentEvents[indexPath.row], tapBack: nil)
+        
+        return assessmentCell
     }
 }
 

--- a/BackPortal/ViewControllers/ActiviesViewController.swift
+++ b/BackPortal/ViewControllers/ActiviesViewController.swift
@@ -8,6 +8,7 @@ class ActiviesViewController: UICollectionViewController {
     // MARK: Private properties
     
     fileprivate var interventionEvents: [[OCKCarePlanEvent]] = []
+    fileprivate var assessmentEvents: [[OCKCarePlanEvent]] = []
     fileprivate var lastRenderedBounds: CGRect?
     
     
@@ -112,15 +113,25 @@ fileprivate extension ActiviesViewController {
         
         let todayComponents = NSDateComponents(date: date, calendar: Calendar.current) as DateComponents
         
-        patient.store.events(onDate: todayComponents, type: .intervention) { (events, error) in
-            guard nil == error else {
-                print("[PORTAL] Error getting events: \(error!)")
+        patient.store.events(onDate: todayComponents, type: .intervention) { (interventions, interventionError) in
+            guard nil == interventionError else {
+                print("[PORTAL] Error getting interventions: \(interventionError!)")
                 return
             }
             
-            self.interventionEvents = events
-            onMain {
-                self.collectionView?.reloadData()
+            patient.store.events(onDate: todayComponents, type: .assessment) { (assessments, assessmentError) in
+                guard nil == assessmentError else {
+                    print("[PORTAL] Error getting assessments: \(assessmentError!)")
+                    return
+                }
+                
+                
+                self.interventionEvents = interventions
+                self.assessmentEvents = assessments
+                
+                onMain {
+                    self.collectionView?.reloadData()
+                }
             }
         }
     }

--- a/BackPortal/ViewControllers/ActiviesViewController.swift
+++ b/BackPortal/ViewControllers/ActiviesViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
-import CareKit.NSDateComponents_CarePlan
+import CareKit
+import ResearchKit
 
 fileprivate let InterventionActivityReuseIdentifier = "InterventionCell"
 fileprivate let AssessmentActivityReuseIdentifier = "AssessmentCell"
@@ -92,6 +93,30 @@ extension ActiviesViewController {
     }
 }
 
+// MARK: UICollectionViewDelegate
+
+extension ActiviesViewController {
+    
+    override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard
+            1 == indexPath.section,
+            indexPath.row < assessmentEvents.count,
+            let taskVC = taskViewController(for: assessmentEvents[indexPath.row].first)
+        else {
+            return
+        }
+        
+        present(taskVC, animated: true, completion: nil)
+    }
+}
+
+extension ActiviesViewController: ORKTaskViewControllerDelegate {
+    
+    func taskViewController(_ taskViewController: ORKTaskViewController, didFinishWith reason: ORKTaskViewControllerFinishReason, error: Error?) {
+        dismiss(animated: true, completion: nil)
+    }
+}
+
 // MARK: Private Helpers
 
 fileprivate extension ActiviesViewController {
@@ -180,6 +205,23 @@ fileprivate extension ActiviesViewController {
         
         return assessmentCell
     }
+    
+    func taskViewController(for assessmentEvent: OCKCarePlanEvent?) -> ORKTaskViewController? {
+        guard
+            let assessmentEvent = assessmentEvent,
+            case .assessment = assessmentEvent.activity.type,
+            let task = AssessmentTasks.taskFor(identifier: assessmentEvent.activity.identifier)
+        else {
+            return nil
+        }
+        
+        let taskVC = ORKTaskViewController(task: task, taskRun: nil)
+        taskVC.modalPresentationStyle = .formSheet
+        taskVC.showsProgressInNavigationBar = false
+        taskVC.delegate = self
+        
+        return taskVC
+    }
 }
 
 fileprivate func toggledState(for event: OCKCarePlanEvent) -> OCKCarePlanEventState {
@@ -192,36 +234,3 @@ fileprivate func toggledState(for event: OCKCarePlanEvent) -> OCKCarePlanEventSt
         return .completed
     }
 }
-
-// MARK: UICollectionViewDelegate
-
-//extension ActiviesViewController {
-    /*
-    // Uncomment this method to specify if the specified item should be highlighted during tracking
-    override func collectionView(_ collectionView: UICollectionView, shouldHighlightItemAt indexPath: IndexPath) -> Bool {
-        return true
-    }
-    */
-
-    /*
-    // Uncomment this method to specify if the specified item should be selected
-    override func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
-        return true
-    }
-    */
-
-    /*
-    // Uncomment these methods to specify if an action menu should be displayed for the specified item, and react to actions performed on the item
-    override func collectionView(_ collectionView: UICollectionView, shouldShowMenuForItemAt indexPath: IndexPath) -> Bool {
-        return false
-    }
-
-    override func collectionView(_ collectionView: UICollectionView, canPerformAction action: Selector, forItemAt indexPath: IndexPath, withSender sender: Any?) -> Bool {
-        return false
-    }
-
-    override func collectionView(_ collectionView: UICollectionView, performAction action: Selector, forItemAt indexPath: IndexPath, withSender sender: Any?) {
-    
-    }
-    */
-//}

--- a/BackPortal/ViewControllers/ActiviesViewController.swift
+++ b/BackPortal/ViewControllers/ActiviesViewController.swift
@@ -63,7 +63,7 @@ extension ActiviesViewController: UICollectionViewDelegateFlowLayout {
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
-        return UIEdgeInsets(top: 0.0, left: PortalCellContainerEdgeSpacing, bottom: 0.0, right: PortalCellContainerEdgeSpacing)
+        return UIEdgeInsets(top: 0.0, left: PortalCellContainerEdgeSpacing, bottom: 24.0, right: PortalCellContainerEdgeSpacing)
     }
 }
 

--- a/BackPortal/ViewControllers/ActiviesViewController.swift
+++ b/BackPortal/ViewControllers/ActiviesViewController.swift
@@ -132,35 +132,7 @@ extension ActiviesViewController: ORKTaskViewControllerDelegate {
             return
         }
         
-        if let scaleResult = stepResult.firstResult as? ORKScaleQuestionResult,
-           let scaleAnswer = scaleResult.scaleAnswer
-        {
-            let eventResult = OCKCarePlanEventResult(valueString: scaleAnswer.stringValue, unitString: NSLocalizedString("out of 10", comment: ""), userInfo: nil)
-            
-            selectedPatient?.store.update(event, with: eventResult, state: .completed) { [weak self] (success, event, error) in
-                guard nil == error else {
-                    print("[PORTAL] Error Updating Assessment Event: \(error!)")
-                    return
-                }
-                
-                self?.updateData(on: Date())
-            }
-        } else if
-            let weightResult = stepResult.firstResult as? ORKNumericQuestionResult,
-            let weightAnswer = weightResult.numericAnswer,
-            let weightUnit = weightResult.unit
-        {
-            let eventResult = OCKCarePlanEventResult(valueString: weightAnswer.stringValue, unitString: weightUnit, userInfo: nil)
-            
-            selectedPatient?.store.update(event, with: eventResult, state: .completed) { [weak self] (success, event, error) in
-                guard nil == error else {
-                    print("[PORTAL] Error Updating Assessment Event \(error!)")
-                    return
-                }
-                
-                self?.updateData(on: Date())
-            }
-        }
+        updateAssessment(event: event, withResults: stepResult)
     }
 }
 
@@ -216,6 +188,39 @@ fileprivate extension ActiviesViewController {
             }
             
             self?.updateData(on: Date())
+        }
+    }
+    
+    func updateAssessment(event: OCKCarePlanEvent, withResults stepResult: ORKStepResult) {
+        if
+            let scaleResult = stepResult.firstResult as? ORKScaleQuestionResult,
+            let scaleAnswer = scaleResult.scaleAnswer
+        {
+            let eventResult = OCKCarePlanEventResult(valueString: scaleAnswer.stringValue, unitString: NSLocalizedString("out of 10", comment: ""), userInfo: nil)
+            
+            selectedPatient?.store.update(event, with: eventResult, state: .completed) { [weak self] (success, event, error) in
+                guard nil == error else {
+                    print("[PORTAL] Error Updating Assessment Event: \(error!)")
+                    return
+                }
+                
+                self?.updateData(on: Date())
+            }
+        } else if
+            let weightResult = stepResult.firstResult as? ORKNumericQuestionResult,
+            let weightAnswer = weightResult.numericAnswer,
+            let weightUnit = weightResult.unit
+        {
+            let eventResult = OCKCarePlanEventResult(valueString: weightAnswer.stringValue, unitString: weightUnit, userInfo: nil)
+            
+            selectedPatient?.store.update(event, with: eventResult, state: .completed) { [weak self] (success, event, error) in
+                guard nil == error else {
+                    print("[PORTAL] Error Updating Assessment Event \(error!)")
+                    return
+                }
+                
+                self?.updateData(on: Date())
+            }
         }
     }
     

--- a/BackPortal/Views/AssessmentCell.swift
+++ b/BackPortal/Views/AssessmentCell.swift
@@ -5,10 +5,19 @@ typealias AssessmentEventTapCallback = (OCKCarePlanEvent) -> Void
 
 class AssessmentCell: UICollectionViewCell {
     
+    @IBOutlet fileprivate var nameLabel: UILabel?
+    @IBOutlet fileprivate var subLabel: UILabel?
+    
     func configure(with eventList: [OCKCarePlanEvent], tapBack: AssessmentEventTapCallback?) {
+        guard let activity = eventList.first?.activity else {
+            return
+        }
         
         onMain {
             self.layer.cornerRadius = ActivityCellCornerRadius
+            
+            self.nameLabel?.text = activity.title
+            self.subLabel?.text = activity.text
         }
     }
 }

--- a/BackPortal/Views/AssessmentCell.swift
+++ b/BackPortal/Views/AssessmentCell.swift
@@ -7,17 +7,22 @@ class AssessmentCell: UICollectionViewCell {
     
     @IBOutlet fileprivate var nameLabel: UILabel?
     @IBOutlet fileprivate var subLabel: UILabel?
+    @IBOutlet fileprivate var valueLabel: UILabel?
+    @IBOutlet fileprivate var unitLabel: UILabel?
     
     func configure(with eventList: [OCKCarePlanEvent], tapBack: AssessmentEventTapCallback?) {
-        guard let activity = eventList.first?.activity else {
+        guard let event = eventList.first else {
             return
         }
         
         onMain {
             self.layer.cornerRadius = ActivityCellCornerRadius
             
-            self.nameLabel?.text = activity.title
-            self.subLabel?.text = activity.text
+            self.nameLabel?.text = event.activity.title
+            self.subLabel?.text = event.activity.text
+            self.valueLabel?.textColor = event.activity.tintColor
+            self.valueLabel?.text = event.result?.valueString
+            self.unitLabel?.text = event.result?.unitString
         }
     }
 }

--- a/BackPortal/Views/AssessmentCell.swift
+++ b/BackPortal/Views/AssessmentCell.swift
@@ -1,0 +1,14 @@
+import UIKit
+import CareKit
+
+typealias AssessmentEventTapCallback = (OCKCarePlanEvent) -> Void
+
+class AssessmentCell: UICollectionViewCell {
+    
+    func configure(with eventList: [OCKCarePlanEvent], tapBack: AssessmentEventTapCallback?) {
+        
+        onMain {
+            self.layer.cornerRadius = ActivityCellCornerRadius
+        }
+    }
+}

--- a/BackPortal/Views/Base.lproj/Patients.storyboard
+++ b/BackPortal/Views/Base.lproj/Patients.storyboard
@@ -39,7 +39,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="meJ-oo-LPF">
-                                <rect key="frame" x="0.0" y="64" width="702.5" height="704"/>
+                                <rect key="frame" x="0.0" y="64" width="703" height="704"/>
                                 <connections>
                                     <segue destination="0eu-cO-tCq" kind="embed" id="W3Z-Mq-a6H"/>
                                 </connections>
@@ -190,7 +190,7 @@
             <objects>
                 <collectionViewController id="0eu-cO-tCq" customClass="ActiviesViewController" customModule="BackPortal" customModuleProvider="target" sceneMemberID="viewController">
                     <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" misplaced="YES" dataMode="prototypes" id="4XY-SU-o9U">
-                        <rect key="frame" x="0.0" y="0.0" width="702.5" height="704"/>
+                        <rect key="frame" x="0.0" y="0.0" width="703" height="704"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" id="qhC-4l-en9">
@@ -254,6 +254,56 @@
                                     <outlet property="nameLabel" destination="ypA-Kp-I7c" id="dNp-4w-HKN"/>
                                     <outlet property="subLabel" destination="6y7-EJ-zGK" id="epz-g5-F8F"/>
                                 </connections>
+                            </collectionViewCell>
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="AssessmentCell" id="PMu-li-Vx0">
+                                <rect key="frame" x="251.5" y="0.0" width="200" height="100"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                                    <rect key="frame" x="0.0" y="0.0" width="200" height="100"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zkN-Ug-4oz" userLabel="Content View">
+                                            <rect key="frame" x="0.0" y="0.0" width="200" height="100"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="WHf-S2-gQ8">
+                                                    <rect key="frame" x="20" y="15.5" width="160" height="24"/>
+                                                    <fontDescription key="fontDescription" type="system" weight="medium" pointSize="20"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Text" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="u3u-V1-hfc">
+                                                    <rect key="frame" x="20" y="37.5" width="160" height="17"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="0Ju-mg-Hms">
+                                                    <rect key="frame" x="20" y="56" width="172" height="36"/>
+                                                </stackView>
+                                            </subviews>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            <constraints>
+                                                <constraint firstAttribute="bottom" secondItem="0Ju-mg-Hms" secondAttribute="bottom" constant="8" id="KTU-3R-WXo"/>
+                                                <constraint firstItem="WHf-S2-gQ8" firstAttribute="centerY" secondItem="zkN-Ug-4oz" secondAttribute="centerY" multiplier="55/100" id="R3b-Lo-mGb"/>
+                                                <constraint firstItem="WHf-S2-gQ8" firstAttribute="leading" secondItem="zkN-Ug-4oz" secondAttribute="leading" constant="20" symbolic="YES" id="bPA-P9-T6I"/>
+                                                <constraint firstItem="0Ju-mg-Hms" firstAttribute="leading" secondItem="u3u-V1-hfc" secondAttribute="leading" id="fBW-3j-mcK"/>
+                                                <constraint firstItem="u3u-V1-hfc" firstAttribute="leading" secondItem="WHf-S2-gQ8" secondAttribute="leading" id="g2i-w4-He5"/>
+                                                <constraint firstAttribute="trailing" secondItem="WHf-S2-gQ8" secondAttribute="trailing" constant="20" symbolic="YES" id="gM5-QY-Qw3"/>
+                                                <constraint firstItem="u3u-V1-hfc" firstAttribute="trailing" secondItem="WHf-S2-gQ8" secondAttribute="trailing" id="jcU-9C-Cph"/>
+                                                <constraint firstAttribute="trailing" secondItem="0Ju-mg-Hms" secondAttribute="trailing" constant="8" id="pIi-yR-9L1"/>
+                                                <constraint firstItem="0Ju-mg-Hms" firstAttribute="top" secondItem="u3u-V1-hfc" secondAttribute="bottom" constant="2" id="xiF-87-8WN"/>
+                                                <constraint firstItem="u3u-V1-hfc" firstAttribute="top" secondItem="WHf-S2-gQ8" secondAttribute="bottom" constant="-2" id="zfa-o4-gdK"/>
+                                            </constraints>
+                                        </view>
+                                    </subviews>
+                                </view>
+                                <constraints>
+                                    <constraint firstItem="zkN-Ug-4oz" firstAttribute="leading" secondItem="PMu-li-Vx0" secondAttribute="leading" id="94v-HZ-bsd"/>
+                                    <constraint firstItem="zkN-Ug-4oz" firstAttribute="top" secondItem="PMu-li-Vx0" secondAttribute="top" id="Y6t-5C-wLY"/>
+                                    <constraint firstAttribute="bottom" secondItem="zkN-Ug-4oz" secondAttribute="bottom" id="igp-fD-AGu"/>
+                                    <constraint firstAttribute="trailing" secondItem="zkN-Ug-4oz" secondAttribute="trailing" id="kbR-0X-TYD"/>
+                                </constraints>
+                                <size key="customSize" width="200" height="100"/>
                             </collectionViewCell>
                         </cells>
                         <connections>

--- a/BackPortal/Views/Base.lproj/Patients.storyboard
+++ b/BackPortal/Views/Base.lproj/Patients.storyboard
@@ -266,25 +266,25 @@
                                             <rect key="frame" x="0.0" y="0.0" width="200" height="100"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="WHf-S2-gQ8">
-                                                    <rect key="frame" x="20" y="15.5" width="160" height="24"/>
+                                                    <rect key="frame" x="20" y="25.5" width="160" height="24"/>
                                                     <fontDescription key="fontDescription" type="system" weight="medium" pointSize="20"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Text" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="u3u-V1-hfc">
-                                                    <rect key="frame" x="20" y="37.5" width="160" height="17"/>
+                                                    <rect key="frame" x="20" y="47.5" width="160" height="17"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="0Ju-mg-Hms">
-                                                    <rect key="frame" x="20" y="56" width="172" height="36"/>
+                                                    <rect key="frame" x="20" y="66" width="172" height="26"/>
                                                 </stackView>
                                             </subviews>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <constraints>
                                                 <constraint firstAttribute="bottom" secondItem="0Ju-mg-Hms" secondAttribute="bottom" constant="8" id="KTU-3R-WXo"/>
-                                                <constraint firstItem="WHf-S2-gQ8" firstAttribute="centerY" secondItem="zkN-Ug-4oz" secondAttribute="centerY" multiplier="55/100" id="R3b-Lo-mGb"/>
+                                                <constraint firstItem="WHf-S2-gQ8" firstAttribute="centerY" secondItem="zkN-Ug-4oz" secondAttribute="centerY" multiplier="75/100" id="R3b-Lo-mGb"/>
                                                 <constraint firstItem="WHf-S2-gQ8" firstAttribute="leading" secondItem="zkN-Ug-4oz" secondAttribute="leading" constant="20" symbolic="YES" id="bPA-P9-T6I"/>
                                                 <constraint firstItem="0Ju-mg-Hms" firstAttribute="leading" secondItem="u3u-V1-hfc" secondAttribute="leading" id="fBW-3j-mcK"/>
                                                 <constraint firstItem="u3u-V1-hfc" firstAttribute="leading" secondItem="WHf-S2-gQ8" secondAttribute="leading" id="g2i-w4-He5"/>
@@ -304,6 +304,10 @@
                                     <constraint firstAttribute="trailing" secondItem="zkN-Ug-4oz" secondAttribute="trailing" id="kbR-0X-TYD"/>
                                 </constraints>
                                 <size key="customSize" width="200" height="100"/>
+                                <connections>
+                                    <outlet property="nameLabel" destination="WHf-S2-gQ8" id="kvp-2R-EZN"/>
+                                    <outlet property="subLabel" destination="u3u-V1-hfc" id="CKD-I6-v0i"/>
+                                </connections>
                             </collectionViewCell>
                         </cells>
                         <connections>

--- a/BackPortal/Views/Base.lproj/Patients.storyboard
+++ b/BackPortal/Views/Base.lproj/Patients.storyboard
@@ -189,7 +189,7 @@
         <scene sceneID="UPg-2c-7Uc">
             <objects>
                 <collectionViewController id="0eu-cO-tCq" customClass="ActiviesViewController" customModule="BackPortal" customModuleProvider="target" sceneMemberID="viewController">
-                    <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" misplaced="YES" dataMode="prototypes" id="4XY-SU-o9U">
+                    <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" id="4XY-SU-o9U">
                         <rect key="frame" x="0.0" y="0.0" width="703" height="704"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
@@ -210,7 +210,7 @@
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6dP-Ky-jCT" userLabel="Content View">
                                             <rect key="frame" x="0.0" y="0.0" width="200" height="100"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ypA-Kp-I7c">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Intervention" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ypA-Kp-I7c">
                                                     <rect key="frame" x="20" y="15.5" width="160" height="24"/>
                                                     <fontDescription key="fontDescription" type="system" weight="medium" pointSize="20"/>
                                                     <nil key="textColor"/>
@@ -265,14 +265,14 @@
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zkN-Ug-4oz" userLabel="Content View">
                                             <rect key="frame" x="0.0" y="0.0" width="200" height="100"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="WHf-S2-gQ8">
-                                                    <rect key="frame" x="20" y="25.5" width="160" height="24"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Assessment" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="WHf-S2-gQ8">
+                                                    <rect key="frame" x="20" y="25.5" width="113" height="24"/>
                                                     <fontDescription key="fontDescription" type="system" weight="medium" pointSize="20"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Text" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="u3u-V1-hfc">
-                                                    <rect key="frame" x="20" y="47.5" width="160" height="17"/>
+                                                    <rect key="frame" x="20" y="47.5" width="113" height="17"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                     <nil key="highlightedColor"/>
@@ -280,19 +280,36 @@
                                                 <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="0Ju-mg-Hms">
                                                     <rect key="frame" x="20" y="66" width="172" height="26"/>
                                                 </stackView>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="10" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.80000000000000004" translatesAutoresizingMaskIntoConstraints="NO" id="A4Y-cY-BAl">
+                                                    <rect key="frame" x="150.5" y="20" width="29.5" height="33.5"/>
+                                                    <fontDescription key="fontDescription" type="system" weight="light" pointSize="28"/>
+                                                    <color key="textColor" red="0.090196078430000007" green="0.72156862749999995" blue="0.72549019609999998" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="units" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.80000000000000004" translatesAutoresizingMaskIntoConstraints="NO" id="lFa-MB-zm7">
+                                                    <rect key="frame" x="152.5" y="49.5" width="27.5" height="14.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                    <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
                                             </subviews>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <constraints>
+                                                <constraint firstItem="lFa-MB-zm7" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="u3u-V1-hfc" secondAttribute="trailing" constant="8" symbolic="YES" id="2GI-hL-mBF"/>
+                                                <constraint firstItem="A4Y-cY-BAl" firstAttribute="bottom" secondItem="WHf-S2-gQ8" secondAttribute="bottom" constant="4" id="8wc-e5-A7X"/>
+                                                <constraint firstItem="lFa-MB-zm7" firstAttribute="top" secondItem="A4Y-cY-BAl" secondAttribute="bottom" constant="-4" id="Fie-Dk-oOa"/>
                                                 <constraint firstAttribute="bottom" secondItem="0Ju-mg-Hms" secondAttribute="bottom" constant="8" id="KTU-3R-WXo"/>
                                                 <constraint firstItem="WHf-S2-gQ8" firstAttribute="centerY" secondItem="zkN-Ug-4oz" secondAttribute="centerY" multiplier="75/100" id="R3b-Lo-mGb"/>
+                                                <constraint firstItem="lFa-MB-zm7" firstAttribute="trailing" secondItem="A4Y-cY-BAl" secondAttribute="trailing" id="a1j-h3-xSk"/>
                                                 <constraint firstItem="WHf-S2-gQ8" firstAttribute="leading" secondItem="zkN-Ug-4oz" secondAttribute="leading" constant="20" symbolic="YES" id="bPA-P9-T6I"/>
                                                 <constraint firstItem="0Ju-mg-Hms" firstAttribute="leading" secondItem="u3u-V1-hfc" secondAttribute="leading" id="fBW-3j-mcK"/>
                                                 <constraint firstItem="u3u-V1-hfc" firstAttribute="leading" secondItem="WHf-S2-gQ8" secondAttribute="leading" id="g2i-w4-He5"/>
-                                                <constraint firstAttribute="trailing" secondItem="WHf-S2-gQ8" secondAttribute="trailing" constant="20" symbolic="YES" id="gM5-QY-Qw3"/>
                                                 <constraint firstItem="u3u-V1-hfc" firstAttribute="trailing" secondItem="WHf-S2-gQ8" secondAttribute="trailing" id="jcU-9C-Cph"/>
                                                 <constraint firstAttribute="trailing" secondItem="0Ju-mg-Hms" secondAttribute="trailing" constant="8" id="pIi-yR-9L1"/>
+                                                <constraint firstAttribute="trailing" secondItem="A4Y-cY-BAl" secondAttribute="trailing" constant="20" symbolic="YES" id="prg-HX-NEk"/>
                                                 <constraint firstItem="0Ju-mg-Hms" firstAttribute="top" secondItem="u3u-V1-hfc" secondAttribute="bottom" constant="2" id="xiF-87-8WN"/>
                                                 <constraint firstItem="u3u-V1-hfc" firstAttribute="top" secondItem="WHf-S2-gQ8" secondAttribute="bottom" constant="-2" id="zfa-o4-gdK"/>
+                                                <constraint firstItem="A4Y-cY-BAl" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="WHf-S2-gQ8" secondAttribute="trailing" constant="8" symbolic="YES" id="zlb-Cf-x6g"/>
                                             </constraints>
                                         </view>
                                     </subviews>
@@ -307,6 +324,8 @@
                                 <connections>
                                     <outlet property="nameLabel" destination="WHf-S2-gQ8" id="kvp-2R-EZN"/>
                                     <outlet property="subLabel" destination="u3u-V1-hfc" id="CKD-I6-v0i"/>
+                                    <outlet property="unitLabel" destination="lFa-MB-zm7" id="lfc-aF-Gbw"/>
+                                    <outlet property="valueLabel" destination="A4Y-cY-BAl" id="eg2-cZ-8rV"/>
                                 </connections>
                             </collectionViewCell>
                         </cells>

--- a/BackPortal/Views/Base.lproj/Patients.storyboard
+++ b/BackPortal/Views/Base.lproj/Patients.storyboard
@@ -255,7 +255,7 @@
                                     <outlet property="subLabel" destination="6y7-EJ-zGK" id="epz-g5-F8F"/>
                                 </connections>
                             </collectionViewCell>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="AssessmentCell" id="PMu-li-Vx0">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="AssessmentCell" id="PMu-li-Vx0" customClass="AssessmentCell" customModule="BackPortal" customModuleProvider="target">
                                 <rect key="frame" x="251.5" y="0.0" width="200" height="100"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">

--- a/BackPortal/Views/InterventionCell.swift
+++ b/BackPortal/Views/InterventionCell.swift
@@ -1,6 +1,8 @@
 import UIKit
 import CareKit
 
+let ActivityCellCornerRadius = 6.0 as CGFloat
+
 typealias InterventionEventTapCallback = (OCKCarePlanEvent) -> Void
 
 class InterventionCell: UICollectionViewCell {
@@ -29,7 +31,7 @@ class InterventionCell: UICollectionViewCell {
         onMain {
             self.resetStackView()
             
-            self.layer.cornerRadius = 6.0
+            self.layer.cornerRadius = ActivityCellCornerRadius
             
             self.nameLabel?.text = activity.title
             self.subLabel?.text = activity.text


### PR DESCRIPTION
Fetches assessment activity events and displays them in the Activities view. Allows the user to tap on an Activity and update the value. Displays a ResearchKit task to collect the data in a modal form sheet, converting the ResearchKit result into a CareKit event result. As always, CMHealth handles the syncing automagically.