### PR TITLE
Allow the User to Add Intervention Activities

### DIFF
--- a/BackPortal.xcodeproj/project.pbxproj
+++ b/BackPortal.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		B499F9EC1F01568900A76098 /* Date+Portal.swift in Sources */ = {isa = PBXBuildFile; fileRef = B499F9EB1F01568900A76098 /* Date+Portal.swift */; };
 		B499F9EE1F016D8000A76098 /* ActivitiesHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B499F9ED1F016D8000A76098 /* ActivitiesHeader.swift */; };
 		B499F9F01F0179CE00A76098 /* NewActivityTasks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B499F9EF1F0179CE00A76098 /* NewActivityTasks.swift */; };
+		B4A17D121F02BE46004FD644 /* InterventionTypeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A17D111F02BE46004FD644 /* InterventionTypeViewController.swift */; };
 		B4C2BE1C1EF823D200E70A31 /* ActiviesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C2BE1B1EF823D200E70A31 /* ActiviesViewController.swift */; };
 		B4C2BE1E1EF8328100E70A31 /* PatientDetailNavController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C2BE1D1EF8328100E70A31 /* PatientDetailNavController.swift */; };
 		E3E647F8FB412EE4983BFCCF /* Pods_BackPortalUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B9CB4F026613D1FC355F9B5 /* Pods_BackPortalUITests.framework */; };
@@ -104,6 +105,7 @@
 		B499F9EB1F01568900A76098 /* Date+Portal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Date+Portal.swift"; sourceTree = "<group>"; };
 		B499F9ED1F016D8000A76098 /* ActivitiesHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivitiesHeader.swift; sourceTree = "<group>"; };
 		B499F9EF1F0179CE00A76098 /* NewActivityTasks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewActivityTasks.swift; sourceTree = "<group>"; };
+		B4A17D111F02BE46004FD644 /* InterventionTypeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterventionTypeViewController.swift; sourceTree = "<group>"; };
 		B4C2BE1B1EF823D200E70A31 /* ActiviesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActiviesViewController.swift; sourceTree = "<group>"; };
 		B4C2BE1D1EF8328100E70A31 /* PatientDetailNavController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatientDetailNavController.swift; sourceTree = "<group>"; };
 		B7D0E29578B809FC4C0276D6 /* Pods-BackPortalTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BackPortalTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-BackPortalTests/Pods-BackPortalTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -270,6 +272,7 @@
 				B4C2BE1D1EF8328100E70A31 /* PatientDetailNavController.swift */,
 				B45316521EF83E0A004A8FD9 /* PatientDetailViewController.swift */,
 				B4C2BE1B1EF823D200E70A31 /* ActiviesViewController.swift */,
+				B4A17D111F02BE46004FD644 /* InterventionTypeViewController.swift */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -575,6 +578,7 @@
 				B4297EDD1EF2D1D300A0DE1F /* PortalAppDelegate.swift in Sources */,
 				B45316571EF84D46004A8FD9 /* UIViewController+Portal.swift in Sources */,
 				B45316531EF83E0A004A8FD9 /* PatientDetailViewController.swift in Sources */,
+				B4A17D121F02BE46004FD644 /* InterventionTypeViewController.swift in Sources */,
 				B4297F1D1EF2D63C00A0DE1F /* ApplicationViewController.swift in Sources */,
 				B4C2BE1C1EF823D200E70A31 /* ActiviesViewController.swift in Sources */,
 				B41DC0311EF32A8B00B7DAE9 /* PatientListViewController.swift in Sources */,

--- a/BackPortal.xcodeproj/project.pbxproj
+++ b/BackPortal.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		B46FEA1E1EFC15C100F9D09E /* AssessmentTasks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46FEA1D1EFC15C100F9D09E /* AssessmentTasks.swift */; };
 		B499F9EC1F01568900A76098 /* Date+Portal.swift in Sources */ = {isa = PBXBuildFile; fileRef = B499F9EB1F01568900A76098 /* Date+Portal.swift */; };
 		B499F9EE1F016D8000A76098 /* ActivitiesHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B499F9ED1F016D8000A76098 /* ActivitiesHeader.swift */; };
+		B499F9F01F0179CE00A76098 /* NewActivityTasks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B499F9EF1F0179CE00A76098 /* NewActivityTasks.swift */; };
 		B4C2BE1C1EF823D200E70A31 /* ActiviesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C2BE1B1EF823D200E70A31 /* ActiviesViewController.swift */; };
 		B4C2BE1E1EF8328100E70A31 /* PatientDetailNavController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C2BE1D1EF8328100E70A31 /* PatientDetailNavController.swift */; };
 		E3E647F8FB412EE4983BFCCF /* Pods_BackPortalUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B9CB4F026613D1FC355F9B5 /* Pods_BackPortalUITests.framework */; };
@@ -100,6 +101,7 @@
 		B46FEA1D1EFC15C100F9D09E /* AssessmentTasks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssessmentTasks.swift; sourceTree = "<group>"; };
 		B499F9EB1F01568900A76098 /* Date+Portal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Date+Portal.swift"; sourceTree = "<group>"; };
 		B499F9ED1F016D8000A76098 /* ActivitiesHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivitiesHeader.swift; sourceTree = "<group>"; };
+		B499F9EF1F0179CE00A76098 /* NewActivityTasks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewActivityTasks.swift; sourceTree = "<group>"; };
 		B4C2BE1B1EF823D200E70A31 /* ActiviesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActiviesViewController.swift; sourceTree = "<group>"; };
 		B4C2BE1D1EF8328100E70A31 /* PatientDetailNavController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatientDetailNavController.swift; sourceTree = "<group>"; };
 		B7D0E29578B809FC4C0276D6 /* Pods-BackPortalTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BackPortalTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-BackPortalTests/Pods-BackPortalTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -273,6 +275,7 @@
 			isa = PBXGroup;
 			children = (
 				B46FEA1D1EFC15C100F9D09E /* AssessmentTasks.swift */,
+				B499F9EF1F0179CE00A76098 /* NewActivityTasks.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -582,6 +585,7 @@
 				B46FEA1B1EFB03C900F9D09E /* AssessmentCell.swift in Sources */,
 				B45316591EF84F87004A8FD9 /* PatientMasterNavController.swift in Sources */,
 				B41DC0331EF3306900B7DAE9 /* PatientCell.swift in Sources */,
+				B499F9F01F0179CE00A76098 /* NewActivityTasks.swift in Sources */,
 				B499F9EE1F016D8000A76098 /* ActivitiesHeader.swift in Sources */,
 				B41DC0161EF2DE3D00B7DAE9 /* DispatchUtils.swift in Sources */,
 				B41DC02F1EF325E600B7DAE9 /* PatientSplitViewController.swift in Sources */,

--- a/BackPortal.xcodeproj/project.pbxproj
+++ b/BackPortal.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		B46FEA1B1EFB03C900F9D09E /* AssessmentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46FEA1A1EFB03C900F9D09E /* AssessmentCell.swift */; };
 		B46FEA1E1EFC15C100F9D09E /* AssessmentTasks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46FEA1D1EFC15C100F9D09E /* AssessmentTasks.swift */; };
 		B499F9EC1F01568900A76098 /* Date+Portal.swift in Sources */ = {isa = PBXBuildFile; fileRef = B499F9EB1F01568900A76098 /* Date+Portal.swift */; };
+		B499F9EE1F016D8000A76098 /* ActivitiesHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B499F9ED1F016D8000A76098 /* ActivitiesHeader.swift */; };
 		B4C2BE1C1EF823D200E70A31 /* ActiviesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C2BE1B1EF823D200E70A31 /* ActiviesViewController.swift */; };
 		B4C2BE1E1EF8328100E70A31 /* PatientDetailNavController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C2BE1D1EF8328100E70A31 /* PatientDetailNavController.swift */; };
 		E3E647F8FB412EE4983BFCCF /* Pods_BackPortalUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B9CB4F026613D1FC355F9B5 /* Pods_BackPortalUITests.framework */; };
@@ -98,6 +99,7 @@
 		B46FEA1A1EFB03C900F9D09E /* AssessmentCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssessmentCell.swift; sourceTree = "<group>"; };
 		B46FEA1D1EFC15C100F9D09E /* AssessmentTasks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssessmentTasks.swift; sourceTree = "<group>"; };
 		B499F9EB1F01568900A76098 /* Date+Portal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Date+Portal.swift"; sourceTree = "<group>"; };
+		B499F9ED1F016D8000A76098 /* ActivitiesHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivitiesHeader.swift; sourceTree = "<group>"; };
 		B4C2BE1B1EF823D200E70A31 /* ActiviesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActiviesViewController.swift; sourceTree = "<group>"; };
 		B4C2BE1D1EF8328100E70A31 /* PatientDetailNavController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatientDetailNavController.swift; sourceTree = "<group>"; };
 		B7D0E29578B809FC4C0276D6 /* Pods-BackPortalTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BackPortalTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-BackPortalTests/Pods-BackPortalTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -243,6 +245,7 @@
 				B41DC0321EF3306900B7DAE9 /* PatientCell.swift */,
 				B453165A1EF97A7D004A8FD9 /* InterventionCell.swift */,
 				B46FEA1A1EFB03C900F9D09E /* AssessmentCell.swift */,
+				B499F9ED1F016D8000A76098 /* ActivitiesHeader.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -579,6 +582,7 @@
 				B46FEA1B1EFB03C900F9D09E /* AssessmentCell.swift in Sources */,
 				B45316591EF84F87004A8FD9 /* PatientMasterNavController.swift in Sources */,
 				B41DC0331EF3306900B7DAE9 /* PatientCell.swift in Sources */,
+				B499F9EE1F016D8000A76098 /* ActivitiesHeader.swift in Sources */,
 				B41DC0161EF2DE3D00B7DAE9 /* DispatchUtils.swift in Sources */,
 				B41DC02F1EF325E600B7DAE9 /* PatientSplitViewController.swift in Sources */,
 			);

--- a/BackPortal.xcodeproj/project.pbxproj
+++ b/BackPortal.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		B45316571EF84D46004A8FD9 /* UIViewController+Portal.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45316561EF84D46004A8FD9 /* UIViewController+Portal.swift */; };
 		B45316591EF84F87004A8FD9 /* PatientMasterNavController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45316581EF84F87004A8FD9 /* PatientMasterNavController.swift */; };
 		B453165B1EF97A7D004A8FD9 /* InterventionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B453165A1EF97A7D004A8FD9 /* InterventionCell.swift */; };
+		B4667C251F02B218006CD724 /* InterventionType.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B4667C241F02B218006CD724 /* InterventionType.storyboard */; };
 		B46FEA1B1EFB03C900F9D09E /* AssessmentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46FEA1A1EFB03C900F9D09E /* AssessmentCell.swift */; };
 		B46FEA1E1EFC15C100F9D09E /* AssessmentTasks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46FEA1D1EFC15C100F9D09E /* AssessmentTasks.swift */; };
 		B499F9EC1F01568900A76098 /* Date+Portal.swift in Sources */ = {isa = PBXBuildFile; fileRef = B499F9EB1F01568900A76098 /* Date+Portal.swift */; };
@@ -97,6 +98,7 @@
 		B45316561EF84D46004A8FD9 /* UIViewController+Portal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+Portal.swift"; sourceTree = "<group>"; };
 		B45316581EF84F87004A8FD9 /* PatientMasterNavController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatientMasterNavController.swift; sourceTree = "<group>"; };
 		B453165A1EF97A7D004A8FD9 /* InterventionCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterventionCell.swift; sourceTree = "<group>"; };
+		B4667C241F02B218006CD724 /* InterventionType.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = InterventionType.storyboard; sourceTree = "<group>"; };
 		B46FEA1A1EFB03C900F9D09E /* AssessmentCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssessmentCell.swift; sourceTree = "<group>"; };
 		B46FEA1D1EFC15C100F9D09E /* AssessmentTasks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssessmentTasks.swift; sourceTree = "<group>"; };
 		B499F9EB1F01568900A76098 /* Date+Portal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Date+Portal.swift"; sourceTree = "<group>"; };
@@ -243,6 +245,7 @@
 				B41DC0141EF2DDB800B7DAE9 /* Authentication.storyboard */,
 				B41DC01F1EF2FAC900B7DAE9 /* MainPanel.storyboard */,
 				B41DC0261EF2FD9100B7DAE9 /* Account.storyboard */,
+				B4667C241F02B218006CD724 /* InterventionType.storyboard */,
 				B41DC02D1EF324E500B7DAE9 /* Patients.storyboard */,
 				B41DC0321EF3306900B7DAE9 /* PatientCell.swift */,
 				B453165A1EF97A7D004A8FD9 /* InterventionCell.swift */,
@@ -398,6 +401,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B41DC0241EF2FD9100B7DAE9 /* Account.storyboard in Resources */,
+				B4667C251F02B218006CD724 /* InterventionType.storyboard in Resources */,
 				B41DC0121EF2DDB800B7DAE9 /* Authentication.storyboard in Resources */,
 				B41DC02B1EF324E500B7DAE9 /* Patients.storyboard in Resources */,
 				B4297EE41EF2D1D300A0DE1F /* Assets.xcassets in Resources */,

--- a/BackPortal/Models/NewActivityTasks.swift
+++ b/BackPortal/Models/NewActivityTasks.swift
@@ -30,11 +30,11 @@ struct NewActitiviesTasks {
         let description = self.description(from: result)
         
         return OCKCarePlanActivity(identifier: identifier,
-                                   groupIdentifier: nil,
+                                   groupIdentifier: ExerciseActivityGroupIdentifier,
                                    type: .intervention,
                                    title: title,
                                    text: description,
-                                   tintColor: nil,
+                                   tintColor: UIColor.orange,
                                    instructions: instructions,
                                    imageURL: nil,
                                    schedule: schedule,
@@ -47,6 +47,8 @@ struct NewActitiviesTasks {
 // MARK: ResearcKit Step Factories
 
 fileprivate extension NewActitiviesTasks {
+    
+    static let ExerciseActivityGroupIdentifier = "Exercises"
     
     static let ExercieNameQuestionIdentifier = "PortalAddExerciseName"
     

--- a/BackPortal/Models/NewActivityTasks.swift
+++ b/BackPortal/Models/NewActivityTasks.swift
@@ -10,13 +10,13 @@ struct NewActitiviesTasks {
         case .exercise:
             return AddExerciseInterventionTask
         case .medication:
-            fatalError() // TODO
+            return AddMedicationInterventionTask
         }
     }
     
     static func carePlanActivity(from result:ORKTaskResult) -> OCKCarePlanActivity? {
         guard
-            "PortalAddInterventionActivity" == result.identifier,
+            AddExerciseInterventionTaskIdentifier == result.identifier,
             let title = title(from: result),
             let repetitions = repetitions(from: result),
             let schedule = schedule(from: result, repetitions: repetitions)
@@ -46,12 +46,43 @@ struct NewActitiviesTasks {
                                    resultResettable: true,
                                    userInfo: nil)
     }
-    
 }
 
-// MARK: ResearcKit Step Factories
+// MARK: ResearchKit Medication Task Factory
 
 fileprivate extension NewActitiviesTasks {
+    
+    static let AddMedicationInterventionTaskIdentifier = "PortalAddMedicationInterventionActivity"
+    
+    static let MedicationActivityGroupIdentifier = "Medications"
+    
+    static var AddMedicationInterventionTask: ORKOrderedTask {
+        let steps = [MedicationNameQuestion]
+        
+        return ORKOrderedTask(identifier: AddMedicationInterventionTaskIdentifier,
+                              steps: steps)
+    }
+    
+    static let MedicationNameQuestionIdentifier = "PortalAddMedicationName"
+    
+    static var MedicationNameQuestion: ORKQuestionStep {
+        let answer = ORKTextAnswerFormat(maximumLength: 50)
+        
+        let question = ORKQuestionStep(identifier: ExercieNameQuestionIdentifier,
+                                       title: NSLocalizedString("Medication Name", comment: ""),
+                                       text: NSLocalizedString("Enter the name of medication the patient will take", comment: ""),
+                                       answer: answer)
+        question.isOptional = false
+        
+        return question
+    }
+}
+
+// MARK: ResearcKit Exercise Task Factory
+
+fileprivate extension NewActitiviesTasks {
+    
+    static let AddExerciseInterventionTaskIdentifier = "PortalAddExerciseInterventionActivity"
     
     static let ExerciseActivityGroupIdentifier = "Exercises"
     
@@ -60,7 +91,7 @@ fileprivate extension NewActitiviesTasks {
                      ExerciseDaysQuestion, ExerciseRepetitionsQuestion,
                      ExerciseInstructionsQuestion]
         
-        return ORKOrderedTask(identifier: "PortalAddInterventionActivity",
+        return ORKOrderedTask(identifier: AddExerciseInterventionTaskIdentifier,
                               steps: steps)
     }
     

--- a/BackPortal/Models/NewActivityTasks.swift
+++ b/BackPortal/Models/NewActivityTasks.swift
@@ -5,13 +5,13 @@ struct NewActitiviesTasks {
     
     // MARK: Public
     
-    static var AddInterventionTask: ORKOrderedTask {
-        let steps = [ExerciseNameQuestion, ExerciseTimeQuestion,
-                     ExerciseDaysQuestion, ExerciseRepetitionsQuestion,
-                     ExerciseInstructionsQuestion]
-        
-        return ORKOrderedTask(identifier: "PortalAddInterventionActivity",
-                              steps: steps)
+    static func task(for subtype: ActivitySubtype) -> ORKOrderedTask {
+        switch subtype {
+        case .exercise:
+            return AddExerciseInterventionTask
+        case .medication:
+            fatalError() // TODO
+        }
     }
     
     static func carePlanActivity(from result:ORKTaskResult) -> OCKCarePlanActivity? {
@@ -54,6 +54,15 @@ struct NewActitiviesTasks {
 fileprivate extension NewActitiviesTasks {
     
     static let ExerciseActivityGroupIdentifier = "Exercises"
+    
+    static var AddExerciseInterventionTask: ORKOrderedTask {
+        let steps = [ExerciseNameQuestion, ExerciseTimeQuestion,
+                     ExerciseDaysQuestion, ExerciseRepetitionsQuestion,
+                     ExerciseInstructionsQuestion]
+        
+        return ORKOrderedTask(identifier: "PortalAddInterventionActivity",
+                              steps: steps)
+    }
     
     static let ExercieNameQuestionIdentifier = "PortalAddExerciseName"
     

--- a/BackPortal/Models/NewActivityTasks.swift
+++ b/BackPortal/Models/NewActivityTasks.swift
@@ -1,4 +1,5 @@
 import ResearchKit
+import CareKit
 
 struct NewActitiviesTasks {
     
@@ -9,6 +10,54 @@ struct NewActitiviesTasks {
         
         return ORKOrderedTask(identifier: "PortalAddInterventionActivity",
                               steps: steps)
+    }
+    
+    static func carePlanActivity(from result:ORKTaskResult?) -> OCKCarePlanActivity? {
+        guard
+            let result = result,
+            "PortalAddInterventionActivity" == result.identifier,
+            let title = title(from: result)
+        else {
+            return nil
+        }
+        
+        let todayComponents = NSDateComponents(date: Date(), calendar: Calendar.current) as DateComponents
+        let schedule = OCKCareSchedule.weeklySchedule(withStartDate: todayComponents,
+                                                      occurrencesOnEachDay: [1, 1, 1, 1, 1, 1, 1])
+        let identifier = "BCM\(title)InterventionActivity"
+        
+        return OCKCarePlanActivity(identifier: identifier,
+                                   groupIdentifier: nil,
+                                   type: .intervention,
+                                   title: title,
+                                   text: nil,
+                                   tintColor: nil,
+                                   instructions: nil,
+                                   imageURL: nil,
+                                   schedule: schedule,
+                                   resultResettable: true,
+                                   userInfo: nil)
+    }
+    
+    private static func title(from taskResult: ORKTaskResult) -> String? {
+        guard let results = taskResult.results else {
+            return nil
+        }
+        
+        return results
+                .flatMap({ $0 as? ORKStepResult })
+                .flatMap({ (stepResult) -> ORKTextQuestionResult? in
+                    guard
+                        let textResult = stepResult.firstResult as? ORKTextQuestionResult,
+                        textResult.identifier == "PortalAddExerciseName"
+                    else {
+                            return nil
+                    }
+                    
+                    return textResult
+                })
+                .first?
+                .textAnswer
     }
     
     private static var ExerciseNameQuestion: ORKQuestionStep {

--- a/BackPortal/Models/NewActivityTasks.swift
+++ b/BackPortal/Models/NewActivityTasks.swift
@@ -3,14 +3,87 @@ import ResearchKit
 struct NewActitiviesTasks {
     
     static var AddInterventionTask: ORKOrderedTask {
-        let textAnswer = ORKTextAnswerFormat(maximumLength: 50)
+        let steps = [ExerciseNameQuestion, ExerciseTimeQuestion,
+                     ExerciseDaysQuestion, ExerciseRepetitionsQuestion,
+                     ExerciseInstructionsQuestion]
         
-        let textQuestion = ORKQuestionStep(identifier: "PortalAddExercieIntervention",
+        return ORKOrderedTask(identifier: "PortalAddInterventionActivity",
+                              steps: steps)
+    }
+    
+    private static var ExerciseNameQuestion: ORKQuestionStep {
+        let answer = ORKTextAnswerFormat(maximumLength: 50)
+        
+        let question = ORKQuestionStep(identifier: "PortalAddExerciseName",
                                            title: NSLocalizedString("Exercise Name", comment: ""),
                                            text: NSLocalizedString("Enter the title for this exercie activity", comment: ""),
-                                           answer: textAnswer)
-        textQuestion.isOptional = false
+                                           answer: answer)
+        question.isOptional = false
         
-        return ORKOrderedTask(identifier: "PortalAddInterventionActivity", steps: [textQuestion])
+        return question
+    }
+    
+    private static var ExerciseTimeQuestion: ORKQuestionStep {
+        let answer = ORKNumericAnswerFormat(style: .integer,
+                                            unit: NSLocalizedString("minutes", comment: ""),
+                                            minimum: NSNumber(value: 1),
+                                            maximum: NSNumber(value: 120))
+        
+        let question = ORKQuestionStep(identifier: "PortalAddExerciseTime",
+                                       title: NSLocalizedString("Duration", comment: ""),
+                                       text: NSLocalizedString("Enter the prescribed exercise duration in minutes", comment: ""),
+                                       answer: answer)
+        question.isOptional = false
+        
+        return question
+    }
+    
+    private static var ExerciseDaysQuestion: ORKQuestionStep {
+        let choices = [ORKTextChoice(text: NSLocalizedString("Monday", comment: ""), value: "M" as NSString),
+                       ORKTextChoice(text: NSLocalizedString("Tuesday", comment: ""), value: "T" as NSString),
+                       ORKTextChoice(text: NSLocalizedString("Wednesday", comment: ""), value: "W" as NSString),
+                       ORKTextChoice(text: NSLocalizedString("Thursday", comment: ""), value: "R" as NSString),
+                       ORKTextChoice(text: NSLocalizedString("Friday", comment: ""), value: "F" as NSString),
+                       ORKTextChoice(text: NSLocalizedString("Saturday", comment: ""), value: "S" as NSString),
+                       ORKTextChoice(text: NSLocalizedString("Sunday", comment: ""), value: "N" as NSString),]
+                       
+                       
+        let answer = ORKTextChoiceAnswerFormat(style: .multipleChoice,
+                                               textChoices: choices)
+        
+        let question = ORKQuestionStep(identifier: "PortalAddExerciseDays",
+                                       title: NSLocalizedString("Days of Week", comment: ""),
+                                       text: NSLocalizedString("Select the days of the week the patient should complete this exercise", comment: ""),
+                                       answer: answer)
+        question.isOptional = false
+        
+        return question
+    }
+    
+    private static var ExerciseRepetitionsQuestion: ORKQuestionStep {
+        let answer = ORKNumericAnswerFormat(style: .integer,
+                                            unit: nil,
+                                            minimum: NSNumber(value: 1),
+                                            maximum: NSNumber(value: 5))
+        
+        let question = ORKQuestionStep(identifier: "PortalAddExerciseRepetitions",
+                                       title: NSLocalizedString("Daily Repetitions", comment: ""),
+                                       text: NSLocalizedString("How many times, per day, should the patient complete this exercise", comment: ""),
+                                       answer: answer)
+        question.isOptional = false
+        
+        return question
+    }
+    
+    private static var ExerciseInstructionsQuestion: ORKQuestionStep {
+        let answer = ORKTextAnswerFormat(maximumLength: 300)
+        
+        let question = ORKQuestionStep(identifier: "PortalAddExerciseInstructions",
+                                       title: NSLocalizedString("Instructions", comment: ""),
+                                       text: NSLocalizedString("Enter the instructions for the patient to follow for this exercise", comment: ""),
+                                       answer: answer)
+        question.isOptional = true
+        
+        return question
     }
 }

--- a/BackPortal/Models/NewActivityTasks.swift
+++ b/BackPortal/Models/NewActivityTasks.swift
@@ -57,7 +57,8 @@ fileprivate extension NewActitiviesTasks {
     static let MedicationActivityGroupIdentifier = "Medications"
     
     static var AddMedicationInterventionTask: ORKOrderedTask {
-        let steps = [MedicationNameQuestion]
+        let steps = [MedicationNameQuestion, MedicationDosageQuestion,
+                     MedicationDaysQuestion]
         
         return ORKOrderedTask(identifier: AddMedicationInterventionTaskIdentifier,
                               steps: steps)
@@ -75,6 +76,31 @@ fileprivate extension NewActitiviesTasks {
         question.isOptional = false
         
         return question
+    }
+    
+    static let MedicationDosageQuestionIdentifier = "PortalAddMedicationDosage"
+    
+    static var MedicationDosageQuestion: ORKQuestionStep {
+        let answer = ORKNumericAnswerFormat(style: .integer,
+                                            unit: NSLocalizedString("mg", comment: ""),
+                                            minimum: NSNumber(value: 1),
+                                            maximum: NSNumber(value: 10000))
+        
+        let question = ORKQuestionStep(identifier: MedicationDosageQuestionIdentifier,
+                                       title: NSLocalizedString("Dosage", comment: ""),
+                                       text: NSLocalizedString("Enter the prescribed dosage in mg", comment: ""),
+                                       answer: answer)
+        question.isOptional = false
+        
+        return question
+    }
+    
+    static let MedicationDaysQuesitonIdentifier = "PortalAddMedicationDays"
+    
+    static var MedicationDaysQuestion: ORKQuestionStep {
+        return daysOfWeekQuestion(identifier: MedicationDaysQuesitonIdentifier,
+                                  title: NSLocalizedString("Days of Week", comment: ""),
+                                  text: NSLocalizedString("Select the days of the week the patient should take this medication", comment: ""))
     }
 }
 
@@ -129,24 +155,9 @@ fileprivate extension NewActitiviesTasks {
     static let ExerciseDaysQuesitonIdentifier = "PortalAddExerciseDays"
     
     static var ExerciseDaysQuestion: ORKQuestionStep {
-        let choices = [ ORKTextChoice(text: NSLocalizedString("Sunday", comment: ""), value: "Su" as NSString),
-                        ORKTextChoice(text: NSLocalizedString("Monday", comment: ""), value: "Mo" as NSString),
-                        ORKTextChoice(text: NSLocalizedString("Tuesday", comment: ""), value: "Tu" as NSString),
-                        ORKTextChoice(text: NSLocalizedString("Wednesday", comment: ""), value: "We" as NSString),
-                        ORKTextChoice(text: NSLocalizedString("Thursday", comment: ""), value: "Th" as NSString),
-                        ORKTextChoice(text: NSLocalizedString("Friday", comment: ""), value: "Fr" as NSString),
-                        ORKTextChoice(text: NSLocalizedString("Saturday", comment: ""), value: "Sa" as NSString), ]
-        
-        let answer = ORKTextChoiceAnswerFormat(style: .multipleChoice,
-                                               textChoices: choices)
-        
-        let question = ORKQuestionStep(identifier: ExerciseDaysQuesitonIdentifier,
-                                       title: NSLocalizedString("Days of Week", comment: ""),
-                                       text: NSLocalizedString("Select the days of the week the patient should complete this exercise", comment: ""),
-                                       answer: answer)
-        question.isOptional = false
-        
-        return question
+        return daysOfWeekQuestion(identifier: ExerciseDaysQuesitonIdentifier,
+                                  title: NSLocalizedString("Days of Week", comment: ""),
+                                  text: NSLocalizedString("Select the days of the week the patient should complete this exercise", comment: ""))
     }
     
     static let ExerciseRepetitionsQuestionIdentifier = "PortalAddExerciseRepetitions"
@@ -176,6 +187,32 @@ fileprivate extension NewActitiviesTasks {
                                        text: NSLocalizedString("Enter the instructions for the patient to follow for this exercise", comment: ""),
                                        answer: answer)
         question.isOptional = true
+        
+        return question
+    }
+}
+
+// MARK: Question Builders
+
+fileprivate extension NewActitiviesTasks {
+    
+    static func daysOfWeekQuestion(identifier: String, title: String, text: String?) -> ORKQuestionStep {
+        let choices = [ ORKTextChoice(text: NSLocalizedString("Sunday", comment: ""), value: "Su" as NSString),
+                        ORKTextChoice(text: NSLocalizedString("Monday", comment: ""), value: "Mo" as NSString),
+                        ORKTextChoice(text: NSLocalizedString("Tuesday", comment: ""), value: "Tu" as NSString),
+                        ORKTextChoice(text: NSLocalizedString("Wednesday", comment: ""), value: "We" as NSString),
+                        ORKTextChoice(text: NSLocalizedString("Thursday", comment: ""), value: "Th" as NSString),
+                        ORKTextChoice(text: NSLocalizedString("Friday", comment: ""), value: "Fr" as NSString),
+                        ORKTextChoice(text: NSLocalizedString("Saturday", comment: ""), value: "Sa" as NSString), ]
+        
+        let answer = ORKTextChoiceAnswerFormat(style: .multipleChoice,
+                                               textChoices: choices)
+        
+        let question = ORKQuestionStep(identifier: identifier,
+                                       title: title,
+                                       text: text,
+                                       answer: answer)
+        question.isOptional = false
         
         return question
     }

--- a/BackPortal/Models/NewActivityTasks.swift
+++ b/BackPortal/Models/NewActivityTasks.swift
@@ -17,23 +17,25 @@ struct NewActitiviesTasks {
     static func carePlanActivity(from result:ORKTaskResult) -> OCKCarePlanActivity? {
         guard
             "PortalAddInterventionActivity" == result.identifier,
-            let title = title(from: result)
+            let title = title(from: result),
+            let repetitions = repetitions(from: result),
+            let schedule = schedule(from: result, repetitions: repetitions)
         else {
             return nil
         }
         
-        let todayComponents = NSDateComponents(date: Date(), calendar: Calendar.current) as DateComponents
-        let schedule = OCKCareSchedule.weeklySchedule(withStartDate: todayComponents,
-                                                      occurrencesOnEachDay: [1, 1, 1, 1, 1, 1, 1])
+
         let identifier = "BCM\(title)InterventionActivity"
+        let instructions = self.instructions(from: result)
+        let description = self.description(from: result)
         
         return OCKCarePlanActivity(identifier: identifier,
                                    groupIdentifier: nil,
                                    type: .intervention,
                                    title: title,
-                                   text: nil,
+                                   text: description,
                                    tintColor: nil,
-                                   instructions: nil,
+                                   instructions: instructions,
                                    imageURL: nil,
                                    schedule: schedule,
                                    resultResettable: true,
@@ -46,10 +48,12 @@ struct NewActitiviesTasks {
 
 fileprivate extension NewActitiviesTasks {
     
+    static let ExercieNameQuestionIdentifier = "PortalAddExerciseName"
+    
     static var ExerciseNameQuestion: ORKQuestionStep {
         let answer = ORKTextAnswerFormat(maximumLength: 50)
         
-        let question = ORKQuestionStep(identifier: "PortalAddExerciseName",
+        let question = ORKQuestionStep(identifier: ExercieNameQuestionIdentifier,
                                            title: NSLocalizedString("Exercise Name", comment: ""),
                                            text: NSLocalizedString("Enter the title for this exercie activity", comment: ""),
                                            answer: answer)
@@ -58,13 +62,15 @@ fileprivate extension NewActitiviesTasks {
         return question
     }
     
+    static let ExerciseTimeQuestionIdentifier = "PortalAddExerciseTime"
+    
     static var ExerciseTimeQuestion: ORKQuestionStep {
         let answer = ORKNumericAnswerFormat(style: .integer,
                                             unit: NSLocalizedString("minutes", comment: ""),
                                             minimum: NSNumber(value: 1),
                                             maximum: NSNumber(value: 120))
         
-        let question = ORKQuestionStep(identifier: "PortalAddExerciseTime",
+        let question = ORKQuestionStep(identifier: ExerciseTimeQuestionIdentifier,
                                        title: NSLocalizedString("Duration", comment: ""),
                                        text: NSLocalizedString("Enter the prescribed exercise duration in minutes", comment: ""),
                                        answer: answer)
@@ -73,20 +79,21 @@ fileprivate extension NewActitiviesTasks {
         return question
     }
     
+    static let ExerciseDaysQuesitonIdentifier = "PortalAddExerciseDays"
+    
     static var ExerciseDaysQuestion: ORKQuestionStep {
-        let choices = [ORKTextChoice(text: NSLocalizedString("Monday", comment: ""), value: "M" as NSString),
-                       ORKTextChoice(text: NSLocalizedString("Tuesday", comment: ""), value: "T" as NSString),
-                       ORKTextChoice(text: NSLocalizedString("Wednesday", comment: ""), value: "W" as NSString),
-                       ORKTextChoice(text: NSLocalizedString("Thursday", comment: ""), value: "R" as NSString),
-                       ORKTextChoice(text: NSLocalizedString("Friday", comment: ""), value: "F" as NSString),
-                       ORKTextChoice(text: NSLocalizedString("Saturday", comment: ""), value: "S" as NSString),
-                       ORKTextChoice(text: NSLocalizedString("Sunday", comment: ""), value: "N" as NSString),]
-                       
-                       
+        let choices = [ ORKTextChoice(text: NSLocalizedString("Sunday", comment: ""), value: "Su" as NSString),
+                        ORKTextChoice(text: NSLocalizedString("Monday", comment: ""), value: "Mo" as NSString),
+                        ORKTextChoice(text: NSLocalizedString("Tuesday", comment: ""), value: "Tu" as NSString),
+                        ORKTextChoice(text: NSLocalizedString("Wednesday", comment: ""), value: "We" as NSString),
+                        ORKTextChoice(text: NSLocalizedString("Thursday", comment: ""), value: "Th" as NSString),
+                        ORKTextChoice(text: NSLocalizedString("Friday", comment: ""), value: "Fr" as NSString),
+                        ORKTextChoice(text: NSLocalizedString("Saturday", comment: ""), value: "Sa" as NSString), ]
+        
         let answer = ORKTextChoiceAnswerFormat(style: .multipleChoice,
                                                textChoices: choices)
         
-        let question = ORKQuestionStep(identifier: "PortalAddExerciseDays",
+        let question = ORKQuestionStep(identifier: ExerciseDaysQuesitonIdentifier,
                                        title: NSLocalizedString("Days of Week", comment: ""),
                                        text: NSLocalizedString("Select the days of the week the patient should complete this exercise", comment: ""),
                                        answer: answer)
@@ -95,13 +102,15 @@ fileprivate extension NewActitiviesTasks {
         return question
     }
     
+    static let ExerciseRepetitionsQuestionIdentifier = "PortalAddExerciseRepetitions"
+    
     static var ExerciseRepetitionsQuestion: ORKQuestionStep {
         let answer = ORKNumericAnswerFormat(style: .integer,
                                             unit: nil,
                                             minimum: NSNumber(value: 1),
                                             maximum: NSNumber(value: 5))
         
-        let question = ORKQuestionStep(identifier: "PortalAddExerciseRepetitions",
+        let question = ORKQuestionStep(identifier: ExerciseRepetitionsQuestionIdentifier,
                                        title: NSLocalizedString("Daily Repetitions", comment: ""),
                                        text: NSLocalizedString("How many times, per day, should the patient complete this exercise", comment: ""),
                                        answer: answer)
@@ -110,10 +119,12 @@ fileprivate extension NewActitiviesTasks {
         return question
     }
     
+    static let ExerciseInstructionsQuestionIdentifier = "PortalAddExerciseInstructions"
+    
     static var ExerciseInstructionsQuestion: ORKQuestionStep {
         let answer = ORKTextAnswerFormat(maximumLength: 300)
         
-        let question = ORKQuestionStep(identifier: "PortalAddExerciseInstructions",
+        let question = ORKQuestionStep(identifier: ExerciseInstructionsQuestionIdentifier,
                                        title: NSLocalizedString("Instructions", comment: ""),
                                        text: NSLocalizedString("Enter the instructions for the patient to follow for this exercise", comment: ""),
                                        answer: answer)
@@ -129,7 +140,58 @@ fileprivate extension NewActitiviesTasks {
     
     static func title(from taskResult: ORKTaskResult) -> String? {
         return
-            extract(from: taskResult, identifier: "PortalAddExerciseName", extractor: { (textResult: ORKTextQuestionResult)in
+            extract(from: taskResult, identifier: ExercieNameQuestionIdentifier, extractor: { (textResult: ORKTextQuestionResult) in
+                return textResult.textAnswer
+            })
+    }
+    
+    static func repetitions(from taskResult: ORKTaskResult) -> Int? {
+        return
+            extract(from: taskResult, identifier: ExerciseRepetitionsQuestionIdentifier, extractor: { (numResult: ORKNumericQuestionResult) in
+                return numResult.numericAnswer?.intValue
+            })
+    }
+    
+    static func description(from taskResult: ORKTaskResult) -> String? {
+        return
+            extract(from: taskResult, identifier: ExerciseTimeQuestionIdentifier, extractor: { (numResult: ORKNumericQuestionResult) in
+                guard
+                    let value = numResult.numericAnswer as? Int,
+                    let units = numResult.unit
+                else {
+                        return nil
+                }
+                
+                return "\(value) \(units)"
+            })
+    }
+    
+    static func schedule(from taskResult: ORKTaskResult, repetitions: Int) -> OCKCareSchedule? {
+        guard
+            let dayList =
+            extract(from: taskResult,
+                    identifier: ExerciseDaysQuesitonIdentifier,
+                    extractor: { (choiceResult: ORKChoiceQuestionResult) -> ([String]?) in
+                        return choiceResult.choiceAnswers as? [String]
+                    })
+        else {
+            return nil
+        }
+        
+        let repSchedule = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"]
+                            .flatMap({ dayList.contains($0) ? 1 : 0 })
+                            .map({ $0 * repetitions })
+                            .map({ NSNumber(value: $0) })
+        
+        let todayComponents = NSDateComponents(date: Date(), calendar: Calendar.current) as DateComponents
+        
+        return OCKCareSchedule.weeklySchedule(withStartDate: todayComponents,
+                                              occurrencesOnEachDay: repSchedule)
+    }
+    
+    static func instructions(from taskResult: ORKTaskResult) -> String? {
+        return
+            extract(from: taskResult, identifier: ExerciseInstructionsQuestionIdentifier, extractor: { (textResult: ORKTextQuestionResult) in
                 return textResult.textAnswer
             })
     }

--- a/BackPortal/Models/NewActivityTasks.swift
+++ b/BackPortal/Models/NewActivityTasks.swift
@@ -58,7 +58,8 @@ fileprivate extension NewActitiviesTasks {
     
     static var AddMedicationInterventionTask: ORKOrderedTask {
         let steps = [MedicationNameQuestion, MedicationDosageQuestion,
-                     MedicationDaysQuestion]
+                     MedicationDaysQuestion, MedicationRepetitionsQuestion,
+                     MedicationInstructionsQuestion]
         
         return ORKOrderedTask(identifier: AddMedicationInterventionTaskIdentifier,
                               steps: steps)
@@ -101,6 +102,37 @@ fileprivate extension NewActitiviesTasks {
         return daysOfWeekQuestion(identifier: MedicationDaysQuesitonIdentifier,
                                   title: NSLocalizedString("Days of Week", comment: ""),
                                   text: NSLocalizedString("Select the days of the week the patient should take this medication", comment: ""))
+    }
+    
+    static let MedicationRepetitionsQuestionIdentifier = "PortalAddMedicationRepetitions"
+    
+    static var MedicationRepetitionsQuestion: ORKQuestionStep {
+        let answer = ORKNumericAnswerFormat(style: .integer,
+                                            unit: nil,
+                                            minimum: NSNumber(value: 1),
+                                            maximum: NSNumber(value: 5))
+        
+        let question = ORKQuestionStep(identifier: MedicationRepetitionsQuestionIdentifier,
+                                       title: NSLocalizedString("Daily Doses", comment: ""),
+                                       text: NSLocalizedString("How many times, per day, should the patient take the prescibed dosage of this medication?", comment: ""),
+                                       answer: answer)
+        question.isOptional = false
+        
+        return question
+    }
+    
+    static let MedicationInstructionsQuestionIdentifier = "PortalAddMedicationInstructions"
+    
+    static var MedicationInstructionsQuestion: ORKQuestionStep {
+        let answer = ORKTextAnswerFormat(maximumLength: 300)
+        
+        let question = ORKQuestionStep(identifier: MedicationInstructionsQuestionIdentifier,
+                                       title: NSLocalizedString("Instructions", comment: ""),
+                                       text: NSLocalizedString("Enter the instructions for the patient to follow when taking this medication", comment: ""),
+                                       answer: answer)
+        question.isOptional = true
+        
+        return question
     }
 }
 

--- a/BackPortal/Models/NewActivityTasks.swift
+++ b/BackPortal/Models/NewActivityTasks.swift
@@ -204,18 +204,21 @@ fileprivate extension NewActitiviesTasks {
         }
         
         guard let questionResult = results
-            .flatMap({ $0 as? ORKStepResult })
-            .flatMap({ (stepResult) -> T? in
-                guard
-                    let questionResult = stepResult.firstResult as? T,
-                    questionResult.identifier == identifier
-                    else {
-                        return nil
-                }
-                
-                return questionResult
-            })
-            .first else { return nil }
+                                    .flatMap({ $0 as? ORKStepResult })
+                                    .flatMap({ (stepResult) -> T? in
+                                                guard
+                                                    let questionResult = stepResult.firstResult as? T,
+                                                    questionResult.identifier == identifier
+                                                else {
+                                                        return nil
+                                                }
+                                                
+                                                return questionResult
+                                            })
+                                    .first
+        else {
+            return nil
+        }
         
         return extractor(questionResult)
     }

--- a/BackPortal/Models/NewActivityTasks.swift
+++ b/BackPortal/Models/NewActivityTasks.swift
@@ -24,8 +24,13 @@ struct NewActitiviesTasks {
             return nil
         }
         
+        // NOTE: This would likely still break on various special characters
+        let strippedTitle = title
+                            .replacingOccurrences(of: " ", with: "-")
+                            .replacingOccurrences(of: "\t", with: "-")
+                            .replacingOccurrences(of: "\n", with: "-")
 
-        let identifier = "BCM\(title)InterventionActivity"
+        let identifier = "BCM\(strippedTitle)InterventionActivity"
         let instructions = self.instructions(from: result)
         let description = self.description(from: result)
         

--- a/BackPortal/Models/NewActivityTasks.swift
+++ b/BackPortal/Models/NewActivityTasks.swift
@@ -1,0 +1,16 @@
+import ResearchKit
+
+struct NewActitiviesTasks {
+    
+    static var AddInterventionTask: ORKOrderedTask {
+        let textAnswer = ORKTextAnswerFormat(maximumLength: 50)
+        
+        let textQuestion = ORKQuestionStep(identifier: "PortalAddExercieIntervention",
+                                           title: NSLocalizedString("Exercise Name", comment: ""),
+                                           text: NSLocalizedString("Enter the title for this exercie activity", comment: ""),
+                                           answer: textAnswer)
+        textQuestion.isOptional = false
+        
+        return ORKOrderedTask(identifier: "PortalAddInterventionActivity", steps: [textQuestion])
+    }
+}

--- a/BackPortal/ViewControllers/ActiviesViewController.swift
+++ b/BackPortal/ViewControllers/ActiviesViewController.swift
@@ -187,7 +187,7 @@ extension ActiviesViewController: ORKTaskViewControllerDelegate {
         }
         
         if let newActivity = NewActitiviesTasks.carePlanActivity(from: taskViewController.result) {
-            print("[PORTAL] Created a new activity from ResearchKit Results: \(newActivity)")
+            insert(activity: newActivity)
         } else {
             updateAssessment(event: lastSelectedAssessment, withResult: taskViewController.result)
         }
@@ -219,6 +219,17 @@ fileprivate extension ActiviesViewController {
         return (parent as? PatientDetailViewController)?.lastSelectedDate
     }
     
+    func insert(activity: OCKCarePlanActivity) {
+        selectedPatient?.store.add(activity, completion: { [weak self] (success, error) in
+            guard success else {
+                print("[PORTAL] Error updating store: \(error!.localizedDescription)")
+                return
+            }
+            
+            self?.reloadData()
+        })
+    }
+    
     func toggle(interventionEvent event: OCKCarePlanEvent) {
         guard case .intervention = event.activity.type else {
             return
@@ -244,7 +255,6 @@ fileprivate extension ActiviesViewController {
         else {
             return
         }
-        
             
         selectedPatient?.store.update(event, with: eventResult, state: .completed) { [weak self] (success, event, error) in
             guard nil == error else {

--- a/BackPortal/ViewControllers/ActiviesViewController.swift
+++ b/BackPortal/ViewControllers/ActiviesViewController.swift
@@ -201,13 +201,18 @@ extension ActiviesViewController: ActivitiesHeaderDelegate {
     func activitiesHeader(_ activitiesHeader: ActivitiesHeader, wantsToShowPopover viewController: UIViewController, from view: UIView) {
         viewController.modalPresentationStyle = .popover
         viewController.popoverPresentationController?.sourceView = view
-        viewController.preferredContentSize = CGSize(width: 320, height: 250)
+        viewController.preferredContentSize = CGSize(width: 320, height: 175)
         
         present(viewController, animated: true, completion: nil)
     }
     
-    func activitiesHeader(_ activitiesHeader: ActivitiesHeader, didSelectAddFor type: ActivitiesHeaderType) {
-        let taskVC = ORKTaskViewController(task: NewActitiviesTasks.AddInterventionTask, taskRun: nil)
+    func activitiesHeader(_ activitiesHeader: ActivitiesHeader, didSelectAddFor subtype: ActivitySubtype) {
+        if nil != presentedViewController {
+            dismiss(animated: false, completion: nil)
+        }
+        
+        let task = NewActitiviesTasks.task(for: subtype)
+        let taskVC = ORKTaskViewController(task: task, taskRun: nil)
         taskVC.modalPresentationStyle = .formSheet
         taskVC.delegate = self
         

--- a/BackPortal/ViewControllers/ActiviesViewController.swift
+++ b/BackPortal/ViewControllers/ActiviesViewController.swift
@@ -186,7 +186,11 @@ extension ActiviesViewController: ORKTaskViewControllerDelegate {
             return
         }
         
-        updateAssessment(event: lastSelectedAssessment, withResult: taskViewController.result)
+        if let newActivity = NewActitiviesTasks.carePlanActivity(from: taskViewController.result) {
+            print("[PORTAL] Created a new activity from ResearchKit Results: \(newActivity)")
+        } else {
+            updateAssessment(event: lastSelectedAssessment, withResult: taskViewController.result)
+        }
     }
 }
 

--- a/BackPortal/ViewControllers/ActiviesViewController.swift
+++ b/BackPortal/ViewControllers/ActiviesViewController.swift
@@ -198,6 +198,14 @@ extension ActiviesViewController: ORKTaskViewControllerDelegate {
 
 extension ActiviesViewController: ActivitiesHeaderDelegate {
     
+    func activitiesHeader(_ activitiesHeader: ActivitiesHeader, wantsToShowPopover viewController: UIViewController, from view: UIView) {
+        viewController.modalPresentationStyle = .popover
+        viewController.popoverPresentationController?.sourceView = view
+        viewController.preferredContentSize = CGSize(width: 320, height: 250)
+        
+        present(viewController, animated: true, completion: nil)
+    }
+    
     func activitiesHeader(_ activitiesHeader: ActivitiesHeader, didSelectAddFor type: ActivitiesHeaderType) {
         let taskVC = ORKTaskViewController(task: NewActitiviesTasks.AddInterventionTask, taskRun: nil)
         taskVC.modalPresentationStyle = .formSheet

--- a/BackPortal/ViewControllers/ActiviesViewController.swift
+++ b/BackPortal/ViewControllers/ActiviesViewController.swift
@@ -139,7 +139,7 @@ extension ActiviesViewController {
             return reusableView
         }
         
-        header.configure(as: type)
+        header.configure(as: type, delegate: self)
         return header
     }
 
@@ -173,6 +173,8 @@ extension ActiviesViewController {
     }
 }
 
+// MARK: ORKTaskViewControllerDelegate
+
 extension ActiviesViewController: ORKTaskViewControllerDelegate {
     
     func taskViewController(_ taskViewController: ORKTaskViewController, didFinishWith reason: ORKTaskViewControllerFinishReason, error: Error?) {
@@ -185,6 +187,19 @@ extension ActiviesViewController: ORKTaskViewControllerDelegate {
         }
         
         updateAssessment(event: lastSelectedAssessment, withResult: taskViewController.result)
+    }
+}
+
+// MARK: ActivitiesHeaderDelegate
+
+extension ActiviesViewController: ActivitiesHeaderDelegate {
+    
+    func activitiesHeader(_ activitiesHeader: ActivitiesHeader, didSelectAddFor type: ActivitiesHeaderType) {
+        let taskVC = ORKTaskViewController(task: NewActitiviesTasks.AddInterventionTask, taskRun: nil)
+        taskVC.modalPresentationStyle = .formSheet
+        taskVC.delegate = self
+        
+        present(taskVC, animated: true, completion: nil)
     }
 }
 

--- a/BackPortal/ViewControllers/ActiviesViewController.swift
+++ b/BackPortal/ViewControllers/ActiviesViewController.swift
@@ -124,6 +124,11 @@ extension ActiviesViewController {
             return 0
         }
     }
+    
+    override func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+        let reusableView = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: "ActivitiesSectionHeader", for: indexPath)
+        return reusableView
+    }
 
     override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         switch indexPath.section {

--- a/BackPortal/ViewControllers/ActiviesViewController.swift
+++ b/BackPortal/ViewControllers/ActiviesViewController.swift
@@ -126,8 +126,21 @@ extension ActiviesViewController {
     }
     
     override func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+        guard UICollectionElementKindSectionHeader == kind else {
+            fatalError("Footers not implemented in collection view")
+        }
+        
         let reusableView = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: "ActivitiesSectionHeader", for: indexPath)
-        return reusableView
+        
+        guard
+            let header = reusableView as? ActivitiesHeader,
+            let type = ActivitiesHeaderType(rawValue: indexPath.section)
+        else {
+            return reusableView
+        }
+        
+        header.configure(as: type)
+        return header
     }
 
     override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {

--- a/BackPortal/ViewControllers/InterventionTypeViewController.swift
+++ b/BackPortal/ViewControllers/InterventionTypeViewController.swift
@@ -1,0 +1,21 @@
+import UIKit
+
+class InterventionTypeViewController: UITableViewController {
+    
+    var selectionCallback: ((ActivitySubtype) -> Void)? = nil
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        switch indexPath.row {
+        case 0:
+            selectionCallback?(.exercise)
+        case 1:
+            selectionCallback?(.medication)
+        default:
+            break
+        }
+    }
+}

--- a/BackPortal/Views/ActivitiesHeader.swift
+++ b/BackPortal/Views/ActivitiesHeader.swift
@@ -1,11 +1,17 @@
 import UIKit
 
+enum InterventionActivitySubtype {
+    case exercise
+    case medicine
+}
+
 enum ActivitiesHeaderType: Int {
     case intervention = 0
     case assessment = 1
 }
 
 protocol ActivitiesHeaderDelegate: class {
+    func activitiesHeader(_ activitiesHeader: ActivitiesHeader, wantsToShowPopover viewController: UIViewController, from view: UIView)
     func activitiesHeader(_ activitiesHeader: ActivitiesHeader, didSelectAddFor type: ActivitiesHeaderType)
 }
 
@@ -44,10 +50,13 @@ class ActivitiesHeader: UICollectionReusableView {
 extension ActivitiesHeader {
     
     @IBAction func didPress(addButton: UIButton) {
-        guard let type = type else {
+        guard
+            let type = type,
+            let selectVC = UIStoryboard(name: "InterventionType", bundle: Bundle.main).instantiateInitialViewController()
+        else {
             return
         }
         
-        delegate?.activitiesHeader(self, didSelectAddFor: type)
+        delegate?.activitiesHeader(self, wantsToShowPopover: selectVC, from: addButton)
     }
 }

--- a/BackPortal/Views/ActivitiesHeader.swift
+++ b/BackPortal/Views/ActivitiesHeader.swift
@@ -1,0 +1,36 @@
+import UIKit
+
+enum ActivitiesHeaderType: Int {
+    case intervention = 0
+    case assessment = 1
+}
+
+class ActivitiesHeader: UICollectionReusableView {
+    
+    // MARK: Outlets
+    
+    @IBOutlet fileprivate var titleLabel: UILabel?
+    @IBOutlet fileprivate var addButton: UIButton?
+    
+    // MARK: Public
+    
+    func configure(as type: ActivitiesHeaderType) {
+        if case .intervention = type {
+            titleLabel?.text = NSLocalizedString("Interventions", comment: "")
+            addButton?.isHidden = false
+        } else if case .assessment = type {
+            titleLabel?.text = NSLocalizedString("Assessments", comment: "")
+            addButton?.isHidden = true
+        }
+    }
+}
+
+
+// MARK: Target-Action
+
+extension ActivitiesHeader {
+    
+    @IBAction func didPress(addButton: UIButton) {
+        print("[PORTAL] Add Interventions")
+    }
+}

--- a/BackPortal/Views/ActivitiesHeader.swift
+++ b/BackPortal/Views/ActivitiesHeader.swift
@@ -1,8 +1,8 @@
 import UIKit
 
-enum InterventionActivitySubtype {
+enum ActivitySubtype {
     case exercise
-    case medicine
+    case medication
 }
 
 enum ActivitiesHeaderType: Int {
@@ -12,7 +12,7 @@ enum ActivitiesHeaderType: Int {
 
 protocol ActivitiesHeaderDelegate: class {
     func activitiesHeader(_ activitiesHeader: ActivitiesHeader, wantsToShowPopover viewController: UIViewController, from view: UIView)
-    func activitiesHeader(_ activitiesHeader: ActivitiesHeader, didSelectAddFor type: ActivitiesHeaderType)
+    func activitiesHeader(_ activitiesHeader: ActivitiesHeader, didSelectAddFor subtype: ActivitySubtype)
 }
 
 
@@ -39,7 +39,7 @@ class ActivitiesHeader: UICollectionReusableView {
             addButton?.isHidden = false
         } else if case .assessment = type {
             titleLabel?.text = NSLocalizedString("Assessments", comment: "")
-            addButton?.isHidden = true
+            addButton?.isHidden = false
         }
     }
 }
@@ -52,9 +52,14 @@ extension ActivitiesHeader {
     @IBAction func didPress(addButton: UIButton) {
         guard
             let type = type,
-            let selectVC = UIStoryboard(name: "InterventionType", bundle: Bundle.main).instantiateInitialViewController()
+            case .intervention = type, // TODO: Implement assessment case
+            let selectVC = UIStoryboard(name: "InterventionType", bundle: Bundle.main).instantiateInitialViewController() as? InterventionTypeViewController
         else {
             return
+        }
+        
+        selectVC.selectionCallback = { subtype in
+            self.delegate?.activitiesHeader(self, didSelectAddFor: subtype)
         }
         
         delegate?.activitiesHeader(self, wantsToShowPopover: selectVC, from: addButton)

--- a/BackPortal/Views/ActivitiesHeader.swift
+++ b/BackPortal/Views/ActivitiesHeader.swift
@@ -5,7 +5,17 @@ enum ActivitiesHeaderType: Int {
     case assessment = 1
 }
 
+protocol ActivitiesHeaderDelegate: class {
+    func activitiesHeader(_ activitiesHeader: ActivitiesHeader, didSelectAddFor type: ActivitiesHeaderType)
+}
+
+
 class ActivitiesHeader: UICollectionReusableView {
+    
+    // MARK: Private Properties
+    
+    fileprivate var type: ActivitiesHeaderType? = nil
+    fileprivate weak var delegate: ActivitiesHeaderDelegate? = nil
     
     // MARK: Outlets
     
@@ -14,7 +24,10 @@ class ActivitiesHeader: UICollectionReusableView {
     
     // MARK: Public
     
-    func configure(as type: ActivitiesHeaderType) {
+    func configure(as type: ActivitiesHeaderType, delegate: ActivitiesHeaderDelegate) {
+        self.type = type
+        self.delegate = delegate
+        
         if case .intervention = type {
             titleLabel?.text = NSLocalizedString("Interventions", comment: "")
             addButton?.isHidden = false
@@ -31,6 +44,10 @@ class ActivitiesHeader: UICollectionReusableView {
 extension ActivitiesHeader {
     
     @IBAction func didPress(addButton: UIButton) {
-        print("[PORTAL] Add Interventions")
+        guard let type = type else {
+            return
+        }
+        
+        delegate?.activitiesHeader(self, didSelectAddFor: type)
     }
 }

--- a/BackPortal/Views/Base.lproj/Patients.storyboard
+++ b/BackPortal/Views/Base.lproj/Patients.storyboard
@@ -39,7 +39,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="meJ-oo-LPF">
-                                <rect key="frame" x="0.0" y="64" width="702.5" height="704"/>
+                                <rect key="frame" x="0.0" y="64" width="703" height="704"/>
                                 <connections>
                                     <segue destination="0eu-cO-tCq" kind="embed" id="W3Z-Mq-a6H"/>
                                 </connections>
@@ -198,7 +198,7 @@
             <objects>
                 <collectionViewController automaticallyAdjustsScrollViewInsets="NO" id="0eu-cO-tCq" customClass="ActiviesViewController" customModule="BackPortal" customModuleProvider="target" sceneMemberID="viewController">
                     <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" id="4XY-SU-o9U">
-                        <rect key="frame" x="0.0" y="0.0" width="702.5" height="704"/>
+                        <rect key="frame" x="0.0" y="0.0" width="703" height="704"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" id="qhC-4l-en9">
@@ -338,7 +338,7 @@
                             </collectionViewCell>
                         </cells>
                         <collectionReusableView key="sectionHeaderView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="ActivitiesSectionHeader" id="rt5-Md-LSf" customClass="ActivitiesHeader" customModule="BackPortal" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="0.0" width="702.5" height="44"/>
+                            <rect key="frame" x="0.0" y="0.0" width="703" height="44"/>
                             <autoresizingMask key="autoresizingMask"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MYM-kB-3kh" userLabel="Content View">
@@ -350,8 +350,8 @@
                                             <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="l0G-wK-QMm">
-                                            <rect key="frame" x="659" y="0.0" width="44" height="44"/>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="l0G-wK-QMm">
+                                            <rect key="frame" x="159.5" y="0.0" width="44" height="44"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="44" id="Vd0-60-aXI"/>
                                             </constraints>
@@ -365,10 +365,10 @@
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                     <constraints>
                                         <constraint firstItem="0s6-wO-g9O" firstAttribute="leading" secondItem="MYM-kB-3kh" secondAttribute="leading" constant="20" symbolic="YES" id="13E-eD-FZL"/>
+                                        <constraint firstItem="l0G-wK-QMm" firstAttribute="leading" secondItem="0s6-wO-g9O" secondAttribute="trailing" constant="8" symbolic="YES" id="E9s-F3-IFf"/>
                                         <constraint firstItem="l0G-wK-QMm" firstAttribute="top" secondItem="MYM-kB-3kh" secondAttribute="top" id="fN3-7H-ehY"/>
                                         <constraint firstAttribute="bottom" secondItem="l0G-wK-QMm" secondAttribute="bottom" id="heH-Vw-3QP"/>
                                         <constraint firstItem="0s6-wO-g9O" firstAttribute="centerY" secondItem="MYM-kB-3kh" secondAttribute="centerY" id="hnd-0p-kHP"/>
-                                        <constraint firstAttribute="trailing" secondItem="l0G-wK-QMm" secondAttribute="trailing" id="kmb-T3-Fxr"/>
                                     </constraints>
                                 </view>
                             </subviews>

--- a/BackPortal/Views/Base.lproj/Patients.storyboard
+++ b/BackPortal/Views/Base.lproj/Patients.storyboard
@@ -197,19 +197,19 @@
         <scene sceneID="UPg-2c-7Uc">
             <objects>
                 <collectionViewController automaticallyAdjustsScrollViewInsets="NO" id="0eu-cO-tCq" customClass="ActiviesViewController" customModule="BackPortal" customModuleProvider="target" sceneMemberID="viewController">
-                    <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" misplaced="YES" dataMode="prototypes" id="4XY-SU-o9U">
+                    <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" id="4XY-SU-o9U">
                         <rect key="frame" x="0.0" y="0.0" width="702.5" height="704"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" id="qhC-4l-en9">
                             <size key="itemSize" width="200" height="100"/>
-                            <size key="headerReferenceSize" width="0.0" height="75"/>
+                            <size key="headerReferenceSize" width="0.0" height="44"/>
                             <size key="footerReferenceSize" width="0.0" height="0.0"/>
                             <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                         </collectionViewFlowLayout>
                         <cells>
                             <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="InterventionCell" id="vGn-ne-mFl" customClass="InterventionCell" customModule="BackPortal" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="75" width="200" height="100"/>
+                                <rect key="frame" x="0.0" y="44" width="200" height="100"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
                                     <rect key="frame" x="0.0" y="0.0" width="200" height="100"/>
@@ -264,7 +264,7 @@
                                 </connections>
                             </collectionViewCell>
                             <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="AssessmentCell" id="PMu-li-Vx0" customClass="AssessmentCell" customModule="BackPortal" customModuleProvider="target">
-                                <rect key="frame" x="251.5" y="75" width="200" height="100"/>
+                                <rect key="frame" x="251.5" y="44" width="200" height="100"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
                                     <rect key="frame" x="0.0" y="0.0" width="200" height="100"/>
@@ -337,24 +337,38 @@
                                 </connections>
                             </collectionViewCell>
                         </cells>
-                        <collectionReusableView key="sectionHeaderView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="ActivitiesSectionHeader" id="rt5-Md-LSf">
-                            <rect key="frame" x="0.0" y="0.0" width="702.5" height="75"/>
+                        <collectionReusableView key="sectionHeaderView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="ActivitiesSectionHeader" id="rt5-Md-LSf" customClass="ActivitiesHeader" customModule="BackPortal" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="0.0" width="702.5" height="44"/>
                             <autoresizingMask key="autoresizingMask"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MYM-kB-3kh" userLabel="Content View">
-                                    <rect key="frame" x="0.0" y="0.0" width="703" height="75"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="703" height="44"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Section Header" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0s6-wO-g9O">
-                                            <rect key="frame" x="20" y="27" width="119" height="21"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                            <nil key="textColor"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Interventions" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0s6-wO-g9O">
+                                            <rect key="frame" x="20" y="9" width="131.5" height="27"/>
+                                            <fontDescription key="fontDescription" type="system" weight="medium" pointSize="22"/>
+                                            <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                             <nil key="highlightedColor"/>
                                         </label>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="l0G-wK-QMm">
+                                            <rect key="frame" x="659" y="0.0" width="44" height="44"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="44" id="Vd0-60-aXI"/>
+                                            </constraints>
+                                            <fontDescription key="fontDescription" type="system" weight="light" pointSize="38"/>
+                                            <state key="normal" title="+"/>
+                                            <connections>
+                                                <action selector="didPressWithAddButton:" destination="rt5-Md-LSf" eventType="touchUpInside" id="KoG-3v-DHz"/>
+                                            </connections>
+                                        </button>
                                     </subviews>
-                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                     <constraints>
                                         <constraint firstItem="0s6-wO-g9O" firstAttribute="leading" secondItem="MYM-kB-3kh" secondAttribute="leading" constant="20" symbolic="YES" id="13E-eD-FZL"/>
+                                        <constraint firstItem="l0G-wK-QMm" firstAttribute="top" secondItem="MYM-kB-3kh" secondAttribute="top" id="fN3-7H-ehY"/>
+                                        <constraint firstAttribute="bottom" secondItem="l0G-wK-QMm" secondAttribute="bottom" id="heH-Vw-3QP"/>
                                         <constraint firstItem="0s6-wO-g9O" firstAttribute="centerY" secondItem="MYM-kB-3kh" secondAttribute="centerY" id="hnd-0p-kHP"/>
+                                        <constraint firstAttribute="trailing" secondItem="l0G-wK-QMm" secondAttribute="trailing" id="kmb-T3-Fxr"/>
                                     </constraints>
                                 </view>
                             </subviews>
@@ -364,6 +378,10 @@
                                 <constraint firstItem="MYM-kB-3kh" firstAttribute="top" secondItem="rt5-Md-LSf" secondAttribute="top" id="Px7-WX-GbQ"/>
                                 <constraint firstItem="MYM-kB-3kh" firstAttribute="leading" secondItem="rt5-Md-LSf" secondAttribute="leading" id="myM-Mi-awx"/>
                             </constraints>
+                            <connections>
+                                <outlet property="addButton" destination="l0G-wK-QMm" id="BC1-lA-y4S"/>
+                                <outlet property="titleLabel" destination="0s6-wO-g9O" id="jvP-ai-yZy"/>
+                            </connections>
                         </collectionReusableView>
                         <connections>
                             <outlet property="dataSource" destination="0eu-cO-tCq" id="Z4k-zh-Wjj"/>

--- a/BackPortal/Views/Base.lproj/Patients.storyboard
+++ b/BackPortal/Views/Base.lproj/Patients.storyboard
@@ -29,7 +29,7 @@
         <!--Patient Name-->
         <scene sceneID="Hd8-4K-eui">
             <objects>
-                <viewController id="ERB-Ib-2Rx" customClass="PatientDetailViewController" customModule="BackPortal" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController automaticallyAdjustsScrollViewInsets="NO" id="ERB-Ib-2Rx" customClass="PatientDetailViewController" customModule="BackPortal" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="gsd-S5-LLr"/>
                         <viewControllerLayoutGuide type="bottom" id="dAv-Wy-m4a"/>
@@ -196,20 +196,20 @@
         <!--Activies View Controller-->
         <scene sceneID="UPg-2c-7Uc">
             <objects>
-                <collectionViewController id="0eu-cO-tCq" customClass="ActiviesViewController" customModule="BackPortal" customModuleProvider="target" sceneMemberID="viewController">
+                <collectionViewController automaticallyAdjustsScrollViewInsets="NO" id="0eu-cO-tCq" customClass="ActiviesViewController" customModule="BackPortal" customModuleProvider="target" sceneMemberID="viewController">
                     <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" misplaced="YES" dataMode="prototypes" id="4XY-SU-o9U">
                         <rect key="frame" x="0.0" y="0.0" width="702.5" height="704"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" id="qhC-4l-en9">
                             <size key="itemSize" width="200" height="100"/>
-                            <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                            <size key="headerReferenceSize" width="0.0" height="75"/>
                             <size key="footerReferenceSize" width="0.0" height="0.0"/>
                             <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                         </collectionViewFlowLayout>
                         <cells>
                             <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="InterventionCell" id="vGn-ne-mFl" customClass="InterventionCell" customModule="BackPortal" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="0.0" width="200" height="100"/>
+                                <rect key="frame" x="0.0" y="75" width="200" height="100"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
                                     <rect key="frame" x="0.0" y="0.0" width="200" height="100"/>
@@ -264,7 +264,7 @@
                                 </connections>
                             </collectionViewCell>
                             <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="AssessmentCell" id="PMu-li-Vx0" customClass="AssessmentCell" customModule="BackPortal" customModuleProvider="target">
-                                <rect key="frame" x="251.5" y="0.0" width="200" height="100"/>
+                                <rect key="frame" x="251.5" y="75" width="200" height="100"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
                                     <rect key="frame" x="0.0" y="0.0" width="200" height="100"/>
@@ -337,6 +337,34 @@
                                 </connections>
                             </collectionViewCell>
                         </cells>
+                        <collectionReusableView key="sectionHeaderView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="ActivitiesSectionHeader" id="rt5-Md-LSf">
+                            <rect key="frame" x="0.0" y="0.0" width="702.5" height="75"/>
+                            <autoresizingMask key="autoresizingMask"/>
+                            <subviews>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MYM-kB-3kh" userLabel="Content View">
+                                    <rect key="frame" x="0.0" y="0.0" width="703" height="75"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Section Header" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0s6-wO-g9O">
+                                            <rect key="frame" x="20" y="27" width="119" height="21"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    <constraints>
+                                        <constraint firstItem="0s6-wO-g9O" firstAttribute="leading" secondItem="MYM-kB-3kh" secondAttribute="leading" constant="20" symbolic="YES" id="13E-eD-FZL"/>
+                                        <constraint firstItem="0s6-wO-g9O" firstAttribute="centerY" secondItem="MYM-kB-3kh" secondAttribute="centerY" id="hnd-0p-kHP"/>
+                                    </constraints>
+                                </view>
+                            </subviews>
+                            <constraints>
+                                <constraint firstAttribute="trailing" secondItem="MYM-kB-3kh" secondAttribute="trailing" id="4ba-u5-BjO"/>
+                                <constraint firstAttribute="bottom" secondItem="MYM-kB-3kh" secondAttribute="bottom" id="A5i-nF-QUq"/>
+                                <constraint firstItem="MYM-kB-3kh" firstAttribute="top" secondItem="rt5-Md-LSf" secondAttribute="top" id="Px7-WX-GbQ"/>
+                                <constraint firstItem="MYM-kB-3kh" firstAttribute="leading" secondItem="rt5-Md-LSf" secondAttribute="leading" id="myM-Mi-awx"/>
+                            </constraints>
+                        </collectionReusableView>
                         <connections>
                             <outlet property="dataSource" destination="0eu-cO-tCq" id="Z4k-zh-Wjj"/>
                             <outlet property="delegate" destination="0eu-cO-tCq" id="Fqc-Yz-mYn"/>

--- a/BackPortal/Views/InterventionType.storyboard
+++ b/BackPortal/Views/InterventionType.storyboard
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="uh8-ak-BLR">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Intervention Type-->
+        <scene sceneID="5Ht-rY-xQs">
+            <objects>
+                <tableViewController id="86k-DL-Odb" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="pYx-E2-HEf">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="w1G-zd-ZUn">
+                                <rect key="frame" x="0.0" y="28" width="375" height="44"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="w1G-zd-ZUn" id="Kgs-Tb-ET5">
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="86k-DL-Odb" id="I5s-UA-bQm"/>
+                            <outlet property="delegate" destination="86k-DL-Odb" id="uNR-Lm-jc2"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="Intervention Type" id="Dgd-qP-tOu"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="CxS-Kb-Cpw" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="265" y="143"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="BPd-Dr-xAJ">
+            <objects>
+                <navigationController id="uh8-ak-BLR" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="pjJ-TQ-v0z">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="86k-DL-Odb" kind="relationship" relationship="rootViewController" id="Dmn-o0-c0C"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="gMV-MO-sJH" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-687" y="143"/>
+        </scene>
+    </scenes>
+</document>

--- a/BackPortal/Views/InterventionType.storyboard
+++ b/BackPortal/Views/InterventionType.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="uh8-ak-BLR">
-    <device id="retina4_7" orientation="portrait">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="86k-DL-Odb">
+    <device id="retina3_5" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -12,21 +12,57 @@
         <!--Intervention Type-->
         <scene sceneID="5Ht-rY-xQs">
             <objects>
-                <tableViewController id="86k-DL-Odb" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="pYx-E2-HEf">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                <tableViewController id="86k-DL-Odb" customClass="InterventionTypeViewController" customModule="BackPortal" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="pYx-E2-HEf">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                        <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="w1G-zd-ZUn">
-                                <rect key="frame" x="0.0" y="28" width="375" height="44"/>
-                                <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="w1G-zd-ZUn" id="Kgs-Tb-ET5">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                </tableViewCellContentView>
-                            </tableViewCell>
-                        </prototypes>
+                        <sections>
+                            <tableViewSection id="iha-vu-chc">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="w1G-zd-ZUn">
+                                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="w1G-zd-ZUn" id="Kgs-Tb-ET5">
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Exercise" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b7c-cz-pmC">
+                                                    <rect key="frame" x="20" y="11.5" width="64" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="b7c-cz-pmC" firstAttribute="leading" secondItem="Kgs-Tb-ET5" secondAttribute="leading" constant="20" symbolic="YES" id="s5r-gq-PUh"/>
+                                                <constraint firstItem="b7c-cz-pmC" firstAttribute="centerY" secondItem="Kgs-Tb-ET5" secondAttribute="centerY" id="umQ-hy-K0A"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="lSg-3g-2ZG">
+                                        <rect key="frame" x="0.0" y="44" width="320" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="lSg-3g-2ZG" id="neS-bs-2cM">
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Medication" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vl1-TL-mck">
+                                                    <rect key="frame" x="20" y="11.5" width="85" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="Vl1-TL-mck" firstAttribute="centerY" secondItem="neS-bs-2cM" secondAttribute="centerY" id="D5K-st-Og5"/>
+                                                <constraint firstItem="Vl1-TL-mck" firstAttribute="leading" secondItem="neS-bs-2cM" secondAttribute="leading" constant="20" symbolic="YES" id="ZBw-eS-RMJ"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                        </sections>
                         <connections>
                             <outlet property="dataSource" destination="86k-DL-Odb" id="I5s-UA-bQm"/>
                             <outlet property="delegate" destination="86k-DL-Odb" id="uNR-Lm-jc2"/>
@@ -36,23 +72,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="CxS-Kb-Cpw" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="265" y="143"/>
-        </scene>
-        <!--Navigation Controller-->
-        <scene sceneID="BPd-Dr-xAJ">
-            <objects>
-                <navigationController id="uh8-ak-BLR" sceneMemberID="viewController">
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="pjJ-TQ-v0z">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </navigationBar>
-                    <connections>
-                        <segue destination="86k-DL-Odb" kind="relationship" relationship="rootViewController" id="Dmn-o0-c0C"/>
-                    </connections>
-                </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="gMV-MO-sJH" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="-687" y="143"/>
+            <point key="canvasLocation" x="-278" y="136"/>
         </scene>
     </scenes>
 </document>


### PR DESCRIPTION
* Adds a collection view header that displays the type of activity and exposes a `+` button for adding
* Displays a selection for "Exercise" or "Medication" when the user taps `+` for an Intervention activity
* Shows an appropriate ResearchKit flow to collect data for the new activity
* Extracts data from the ResearchKit result and uses it to create a new `OCKCarePlanActivity` instance
* Adds the instance to the CarePlan store, which CMHealth automagically syncs to the cloud