### PR TITLE
Allow User to Modify Activities

### DIFF
--- a/BackPortal/Lib/Date+Portal.swift
+++ b/BackPortal/Lib/Date+Portal.swift
@@ -11,6 +11,11 @@ extension Date {
         return isSameDay(as: yesterDate)
     }
     
+    var isTomorrow: Bool {
+        let tomorrowDate = Date(timeInterval: 24*60*60, since: Date())
+        return isSameDay(as: tomorrowDate)
+    }
+    
     func isSameDay(as date: Date) -> Bool {
         let selfComponents = NSDateComponents(date: self, calendar: Calendar.current) as DateComponents
         let otherComponents = NSDateComponents(date: date, calendar: Calendar.current) as DateComponents

--- a/BackPortal/ViewControllers/ActiviesViewController.swift
+++ b/BackPortal/ViewControllers/ActiviesViewController.swift
@@ -323,6 +323,17 @@ fileprivate extension ActiviesViewController {
             self?.reloadData()
         }
     }
+    
+    func archive(activity: OCKCarePlanActivity) {
+        selectedPatient?.store.remove(activity) { [weak self] (success, error) in
+            guard success else {
+                print("[PORTAL] Error removing activity: \(error!)")
+                return
+            }
+            
+            self?.reloadData()
+        }
+    }
 }
 
 // MARK: Private Helpers
@@ -400,7 +411,9 @@ fileprivate extension ActiviesViewController {
         }
         
         let archive = UIAlertAction(title: NSLocalizedString("Archive", comment: ""), style: .destructive) { _ in
-            
+            self.showConfirmationAlert(message: NSLocalizedString("Are you sure you want to archive \(activity.title)? The data will be removed from all devices, but saved in the cloud. This action cannot be undone!", comment: "")) {
+                self.archive(activity: activity)
+            }
         }
         
         let cancel = UIAlertAction(title: NSLocalizedString("Cancel", comment: ""), style: .cancel, handler: nil)

--- a/BackPortal/ViewControllers/ActiviesViewController.swift
+++ b/BackPortal/ViewControllers/ActiviesViewController.swift
@@ -330,11 +330,42 @@ fileprivate extension ActiviesViewController {
             case .toggle(let event):
                 self?.toggle(interventionEvent: event)
             case .modify(let activity):
-                print("[PORTAL] Modify activity: \(activity)")
+                self?.showActions(for: activity, from: interventionCell)
             }
         }
         
         return interventionCell
+    }
+    
+    func showActions(for activity: OCKCarePlanActivity, from view: UIView) {
+        guard nil == presentedViewController else {
+            return
+        }
+        
+        let sheet = UIAlertController(title: NSLocalizedString("Modify \(activity.title)", comment: ""),
+                                      message: NSLocalizedString("Select an action to perform on this activity", comment: ""),
+                                      preferredStyle: .actionSheet)
+        
+        let midBounds = CGRect(x: view.bounds.midX - 1, y: view.bounds.midY - 1, width: 3, height: 3)
+        
+        sheet.popoverPresentationController?.sourceView = view
+        sheet.popoverPresentationController?.sourceRect = midBounds
+        
+        let end = UIAlertAction(title: NSLocalizedString("End On This Day", comment: ""), style: .default) { (action) in
+            
+        }
+        
+        let archive = UIAlertAction(title: NSLocalizedString("Archive", comment: ""), style: .destructive) { (action) in
+            
+        }
+        
+        let cancel = UIAlertAction(title: NSLocalizedString("Cancel", comment: ""), style: .cancel, handler: nil)
+        
+        sheet.addAction(end)
+        sheet.addAction(archive)
+        sheet.addAction(cancel)
+        
+        present(sheet, animated: true, completion: nil)
     }
     
     func assessmentCell(from collectionView: UICollectionView, at indexPath: IndexPath) -> UICollectionViewCell {

--- a/BackPortal/ViewControllers/ActiviesViewController.swift
+++ b/BackPortal/ViewControllers/ActiviesViewController.swift
@@ -325,10 +325,13 @@ fileprivate extension ActiviesViewController {
                 return cell
         }
         
-        interventionCell.configure(with: interventionEvents[indexPath.row]) { [weak self] event in
-            print("[PORTAL] Callback for event with occurrence: \(event.occurrenceIndexOfDay)")
-            
-            self?.toggle(interventionEvent: event)
+        interventionCell.configure(with: interventionEvents[indexPath.row]) { [weak self] action in
+            switch action {
+            case .toggle(let event):
+                self?.toggle(interventionEvent: event)
+            case .modify(let activity):
+                print("[PORTAL] Modify activity: \(activity)")
+            }
         }
         
         return interventionCell

--- a/BackPortal/ViewControllers/ActiviesViewController.swift
+++ b/BackPortal/ViewControllers/ActiviesViewController.swift
@@ -394,7 +394,9 @@ fileprivate extension ActiviesViewController {
         sheet.popoverPresentationController?.sourceRect = midBounds
         
         let end = UIAlertAction(title: NSLocalizedString("End On This Day", comment: ""), style: .default) { _ in
-            self.setEndDate(for: activity)
+            self.showConfirmationAlert(message: NSLocalizedString("Are you sure you want to end \(activity.title)? This action cannot be undone!", comment: "")) {
+                self.setEndDate(for: activity)
+            }
         }
         
         let archive = UIAlertAction(title: NSLocalizedString("Archive", comment: ""), style: .destructive) { _ in
@@ -408,6 +410,23 @@ fileprivate extension ActiviesViewController {
         sheet.addAction(cancel)
         
         present(sheet, animated: true, completion: nil)
+    }
+    
+    func showConfirmationAlert(message: String?, action: @escaping () -> Void) {
+        let alert = UIAlertController(title: NSLocalizedString("Are you sure?", comment: ""),
+                                      message: message,
+                                      preferredStyle: .alert)
+        
+        let confirm = UIAlertAction(title: NSLocalizedString("Confirm", comment: ""), style: .destructive) { _ in
+            action()
+        }
+        
+        let cancel = UIAlertAction(title: NSLocalizedString("Cancel", comment: ""), style: .cancel, handler: nil)
+        
+        alert.addAction(confirm)
+        alert.addAction(cancel)
+        
+        present(alert, animated: true, completion: nil)
     }
     
     func taskViewController(for assessmentEvent: OCKCarePlanEvent?) -> ORKTaskViewController? {

--- a/BackPortal/ViewControllers/ActiviesViewController.swift
+++ b/BackPortal/ViewControllers/ActiviesViewController.swift
@@ -300,7 +300,7 @@ fileprivate extension ActiviesViewController {
         guard
             let taskResult = taskResult,
             let event = lastSelectedAssessment,
-            let eventResult = eventResult(from: taskResult)
+            let eventResult = AssessmentTasks.eventResult(from: taskResult)
         else {
             return
         }
@@ -313,50 +313,6 @@ fileprivate extension ActiviesViewController {
             
             self?.reloadData()
         }
-    }
-    
-    func eventResult(from taskResult: ORKTaskResult) -> OCKCarePlanEventResult? {
-        guard let stepResult = taskResult.firstResult as? ORKStepResult else {
-            return nil
-        }
-        
-        switch taskResult.identifier {
-        case AssessmentTasks.WeightIdentifier:
-            return weightResult(from: stepResult)
-        case AssessmentTasks.MoodIdentifier:
-            return scaleResult(from: stepResult)
-        case AssessmentTasks.PainIdentifier:
-            return scaleResult(from: stepResult)
-        default:
-            return nil
-        }
-    }
-    
-    func weightResult(from stepResult: ORKStepResult) -> OCKCarePlanEventResult? {
-        guard
-            let weightResult = stepResult.firstResult as? ORKNumericQuestionResult,
-            let weightAnswer = weightResult.numericAnswer,
-            let weightUnit = weightResult.unit
-        else {
-            return nil
-        }
-        
-        return OCKCarePlanEventResult(valueString: weightAnswer.stringValue,
-                                      unitString: weightUnit,
-                                      userInfo: nil)
-    }
-    
-    func scaleResult(from stepResult: ORKStepResult) -> OCKCarePlanEventResult? {
-        guard
-            let scaleResult = stepResult.firstResult as? ORKScaleQuestionResult,
-            let scaleAnswer = scaleResult.scaleAnswer
-        else {
-            return nil
-        }
-        
-        return OCKCarePlanEventResult(valueString: scaleAnswer.stringValue,
-                                      unitString: NSLocalizedString("out of 10", comment: ""),
-                                      userInfo: nil)
     }
     
     func interventionCell(from collectionView: UICollectionView, at indexPath: IndexPath) -> UICollectionViewCell {

--- a/BackPortal/ViewControllers/ActiviesViewController.swift
+++ b/BackPortal/ViewControllers/ActiviesViewController.swift
@@ -378,7 +378,13 @@ fileprivate extension ActiviesViewController {
             return cell
         }
         
-        assessmentCell.configure(with: assessmentEvents[indexPath.row], tapBack: nil)
+        assessmentCell.configure(with: assessmentEvents[indexPath.row]) { [weak self] action in
+            guard case .modify(let activity) = action else {
+                return
+            }
+            
+            self?.showActions(for: activity, from: assessmentCell)
+        }
         
         return assessmentCell
     }

--- a/BackPortal/ViewControllers/PatientDetailViewController.swift
+++ b/BackPortal/ViewControllers/PatientDetailViewController.swift
@@ -53,7 +53,7 @@ extension PatientDetailViewController {
         
         let datePicker = UIDatePicker(frame: datePickerView.frame)
         datePicker.datePickerMode = .date
-        datePicker.maximumDate = Date()
+        //datePicker.maximumDate = Date()
         datePicker.setDate(lastSelectedDate, animated: false)
         datePicker.addTarget(self, action: #selector(selectedDate(from:)), for: .valueChanged)
         
@@ -96,6 +96,8 @@ private extension PatientDetailViewController {
             return NSLocalizedString("Today", comment: "")
         } else if date.isYesterday {
             return NSLocalizedString("Yesterday", comment: "")
+        } else if date.isTomorrow {
+            return NSLocalizedString("Tomorrow", comment: "")
         }
         
         return self.formatter.string(from: date)

--- a/BackPortal/ViewControllers/PatientListViewController.swift
+++ b/BackPortal/ViewControllers/PatientListViewController.swift
@@ -31,7 +31,7 @@ class PatientListViewController: UITableViewController {
         super.viewDidLoad()
         
         activeObserver = NotificationCenter.default.addObserver(forName: .UIApplicationDidBecomeActive, object: nil, queue: nil) { _ in
-            self.fetchPatients()
+            //self.fetchPatients()
         }
     }
     

--- a/BackPortal/ViewControllers/PatientListViewController.swift
+++ b/BackPortal/ViewControllers/PatientListViewController.swift
@@ -32,6 +32,7 @@ class PatientListViewController: UITableViewController {
         onMain {
             self.tableView?.reloadData()
             self.refreshControl?.endRefreshing()
+            self.performSegue(withIdentifier: "NoSelectionDetail", sender: nil)
         }
     }
 }

--- a/BackPortal/ViewControllers/PatientListViewController.swift
+++ b/BackPortal/ViewControllers/PatientListViewController.swift
@@ -12,6 +12,8 @@ class PatientListViewController: UITableViewController {
     }
     
     fileprivate var hasCompletedFirstFetch = false
+    fileprivate var originalOffset = CGPoint(x: 0, y: 0)
+    fileprivate var activeObserver: NSObjectProtocol? = nil
     
     // MARK: Public Properties
     
@@ -27,10 +29,16 @@ class PatientListViewController: UITableViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        activeObserver = NotificationCenter.default.addObserver(forName: .UIApplicationDidBecomeActive, object: nil, queue: nil) { _ in
+            self.fetchPatients()
+        }
     }
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        
+        originalOffset = tableView?.contentOffset ?? originalOffset
         
         if !hasCompletedFirstFetch {
             fetchPatients()
@@ -41,7 +49,14 @@ class PatientListViewController: UITableViewController {
         onMain {
             self.tableView?.reloadData()
             self.refreshControl?.endRefreshing()
+            self.tableView?.setContentOffset(self.originalOffset, animated: true)
             self.performSegue(withIdentifier: "NoSelectionDetail", sender: nil)
+        }
+    }
+    
+    deinit {
+        if let activeObserver = activeObserver {
+            NotificationCenter.default.removeObserver(activeObserver)
         }
     }
 }

--- a/BackPortal/ViewControllers/PatientListViewController.swift
+++ b/BackPortal/ViewControllers/PatientListViewController.swift
@@ -11,6 +11,8 @@ class PatientListViewController: UITableViewController {
         }
     }
     
+    fileprivate var hasCompletedFirstFetch = false
+    
     // MARK: Public Properties
     
     var selectedPatient: OCKPatient? {
@@ -25,7 +27,14 @@ class PatientListViewController: UITableViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        fetchPatients()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        if !hasCompletedFirstFetch {
+            fetchPatients()
+        }
     }
     
     private func renderUI() {
@@ -92,6 +101,8 @@ private extension PatientListViewController {
     func fetchPatients() {
         onMain {
             self.refreshControl?.beginRefreshing()
+            let yOffset = (self.tableView?.contentOffset.y ?? 0.0) - (self.refreshControl?.frame.size.height ?? 0.0)
+            self.tableView?.setContentOffset(CGPoint(x: 0, y: yOffset), animated: true)
         }
         
         CMHCarePlanStore.fetchAllPatients { (success, patients, errors) in
@@ -100,6 +111,7 @@ private extension PatientListViewController {
                 return
             }
             
+            self.hasCompletedFirstFetch = true
             self.patients = patients
         }
     }

--- a/BackPortal/Views/AssessmentCell.swift
+++ b/BackPortal/Views/AssessmentCell.swift
@@ -1,19 +1,47 @@
 import UIKit
 import CareKit
 
-typealias AssessmentEventTapCallback = (OCKCarePlanEvent) -> Void
+enum AssessmentCellTapbackAction {
+    case modify(OCKCarePlanActivity)
+}
+
+typealias AssessmentEventTapCallback = (AssessmentCellTapbackAction) -> Void
 
 class AssessmentCell: UICollectionViewCell {
+    
+    // MARK: Outlets
     
     @IBOutlet fileprivate var nameLabel: UILabel?
     @IBOutlet fileprivate var subLabel: UILabel?
     @IBOutlet fileprivate var valueLabel: UILabel?
     @IBOutlet fileprivate var unitLabel: UILabel?
     
+    // MARK: Private Properties
+    
+    fileprivate var tapBack: AssessmentEventTapCallback? = nil
+    fileprivate var event: OCKCarePlanEvent? = nil
+    
+    // MARK: Lifcycle
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        
+        let longPress = UILongPressGestureRecognizer(target: self, action: #selector(didLongPress(gesture:)))
+        contentView.addGestureRecognizer(longPress)
+    }
+    
+    // MARK: Public
+    
     func configure(with eventList: [OCKCarePlanEvent], tapBack: AssessmentEventTapCallback?) {
-        guard let event = eventList.first else {
+        guard
+            let event = eventList.first,
+            case .assessment = event.activity.type
+        else {
             return
         }
+        
+        self.event = event
+        self.tapBack = tapBack
         
         onMain {
             self.layer.cornerRadius = ActivityCellCornerRadius
@@ -24,5 +52,18 @@ class AssessmentCell: UICollectionViewCell {
             self.valueLabel?.text = event.result?.valueString
             self.unitLabel?.text = event.result?.unitString
         }
+    }
+}
+
+// MARK: Target-Action
+
+fileprivate extension AssessmentCell {
+    
+    @objc func didLongPress(gesture: UILongPressGestureRecognizer) {
+        guard let activity = event?.activity else {
+            return
+        }
+        
+        tapBack?(.modify(activity))
     }
 }

--- a/BackPortal/Views/Base.lproj/Patients.storyboard
+++ b/BackPortal/Views/Base.lproj/Patients.storyboard
@@ -24,7 +24,7 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="5gP-rf-912" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="846" y="180"/>
+            <point key="canvasLocation" x="859" y="205"/>
         </scene>
         <!--Patient Name-->
         <scene sceneID="Hd8-4K-eui">
@@ -39,7 +39,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="meJ-oo-LPF">
-                                <rect key="frame" x="0.0" y="64" width="703" height="704"/>
+                                <rect key="frame" x="0.0" y="64" width="702.5" height="704"/>
                                 <connections>
                                     <segue destination="0eu-cO-tCq" kind="embed" id="W3Z-Mq-a6H"/>
                                 </connections>
@@ -127,6 +127,9 @@
                             <action selector="didPullWithRefreshControl:" destination="cGM-zU-NGq" eventType="valueChanged" id="XeG-cs-AsU"/>
                         </connections>
                     </refreshControl>
+                    <connections>
+                        <segue destination="M9U-A2-3ko" kind="showDetail" identifier="NoSelectionDetail" id="63N-c5-hvd"/>
+                    </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="qZa-jh-hR2" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
@@ -177,7 +180,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="nwt-D3-Seh" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="49" y="329"/>
+            <point key="canvasLocation" x="49" y="249"/>
         </scene>
         <!--Patients-->
         <scene sceneID="e5b-1M-bZU">
@@ -198,7 +201,7 @@
             <objects>
                 <collectionViewController automaticallyAdjustsScrollViewInsets="NO" id="0eu-cO-tCq" customClass="ActiviesViewController" customModule="BackPortal" customModuleProvider="target" sceneMemberID="viewController">
                     <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" id="4XY-SU-o9U">
-                        <rect key="frame" x="0.0" y="0.0" width="703" height="704"/>
+                        <rect key="frame" x="0.0" y="0.0" width="702.5" height="704"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" id="qhC-4l-en9">
@@ -338,7 +341,7 @@
                             </collectionViewCell>
                         </cells>
                         <collectionReusableView key="sectionHeaderView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="ActivitiesSectionHeader" id="rt5-Md-LSf" customClass="ActivitiesHeader" customModule="BackPortal" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="0.0" width="703" height="44"/>
+                            <rect key="frame" x="0.0" y="0.0" width="702.5" height="44"/>
                             <autoresizingMask key="autoresizingMask"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MYM-kB-3kh" userLabel="Content View">
@@ -397,4 +400,7 @@
     <resources>
         <image name="Patients" width="28" height="28"/>
     </resources>
+    <inferredMetricsTieBreakers>
+        <segue reference="63N-c5-hvd"/>
+    </inferredMetricsTieBreakers>
 </document>

--- a/BackPortal/Views/InterventionCell.swift
+++ b/BackPortal/Views/InterventionCell.swift
@@ -3,7 +3,12 @@ import CareKit
 
 let ActivityCellCornerRadius = 6.0 as CGFloat
 
-typealias InterventionEventTapCallback = (OCKCarePlanEvent) -> Void
+enum InterventionCellTapbackAction {
+    case toggle(OCKCarePlanEvent)
+    case modify(OCKCarePlanActivity)
+}
+
+typealias InterventionEventTapCallback = (InterventionCellTapbackAction) -> Void
 
 class InterventionCell: UICollectionViewCell {
     
@@ -17,6 +22,14 @@ class InterventionCell: UICollectionViewCell {
     
     fileprivate var events: [OCKCarePlanEvent] = []
     fileprivate var tapCallback: InterventionEventTapCallback? = nil
+    
+    // MARK: Override
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        let longPress = UILongPressGestureRecognizer(target: self, action: #selector(didLongPress(gestureRecognizer:)))
+        self.contentView.addGestureRecognizer(longPress)
+    }
     
     // MARK: Public
     
@@ -52,6 +65,19 @@ class InterventionCell: UICollectionViewCell {
     }
 }
 
+// MARK: Target-Action
+
+fileprivate extension InterventionCell {
+    
+    @objc func didLongPress(gestureRecognizer: UILongPressGestureRecognizer) {      
+        guard let activity = events.first?.activity else {
+            return
+        }
+        
+        tapCallback?(.modify(activity))
+    }
+}
+
 // MARK: Private
 
 fileprivate extension InterventionCell {
@@ -82,7 +108,7 @@ fileprivate extension InterventionCell {
             return
         }
         
-        tapCallback?(events[eventButton.tag])
+        tapCallback?(.toggle(events[eventButton.tag]))
     }
     
     func resetStackView() {

--- a/BackPortal/Views/InterventionCell.swift
+++ b/BackPortal/Views/InterventionCell.swift
@@ -69,12 +69,20 @@ class InterventionCell: UICollectionViewCell {
 
 fileprivate extension InterventionCell {
     
-    @objc func didLongPress(gestureRecognizer: UILongPressGestureRecognizer) {      
+    @objc func didLongPress(gestureRecognizer: UILongPressGestureRecognizer) {
         guard let activity = events.first?.activity else {
             return
         }
         
         tapCallback?(.modify(activity))
+    }
+    
+    @objc func didPress(eventButton: UIButton) {
+        guard eventButton.tag < events.count else {
+            return
+        }
+        
+        tapCallback?(.toggle(events[eventButton.tag]))
     }
 }
 
@@ -103,14 +111,6 @@ fileprivate extension InterventionCell {
         return button
     }
     
-    @objc func didPress(eventButton: UIButton) {
-        guard eventButton.tag < events.count else {
-            return
-        }
-        
-        tapCallback?(.toggle(events[eventButton.tag]))
-    }
-    
     func resetStackView() {
         guard let eventsStackView = eventsStackView else {
             return
@@ -118,7 +118,6 @@ fileprivate extension InterventionCell {
         
         while eventsStackView.arrangedSubviews.count > 0 {
             eventsStackView.arrangedSubviews[0].removeFromSuperview()
-            //eventsStackView.removeArrangedSubview(eventsStackView.arrangedSubviews[0])
         }
     }
 }


### PR DESCRIPTION
Allows the user to modify activities by:

* Adding a long press gesture recognizer to activity cells
* Displaying a popover with "End on This Day" and "Archive" options
* Taking the appropriate actions in the local store after user confirmation; changes sync to the cloud automagically thanks to CMHealth ✨ 

Also implements several other small changes:

* Allows pull-to-refresh on the patient activity list, syncing only that patient's local store
* Fixes the spinning glitch when the initial patient fetch occurs at app start up
* Allows the user to select a date in the future to view activity schedule