### PR TITLE
Select New Activity Start Date

### DIFF
--- a/BackPortal/SupportingFiles/Info.plist
+++ b/BackPortal/SupportingFiles/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>3</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>


### PR DESCRIPTION
Allow a step in the ResearchKit flow for adding new activities that let's the user select an explicit start date.